### PR TITLE
refactor(query-client): use mounted QueryClient via useQueryClient hook

### DIFF
--- a/src/app/(public)/blog/[slug]/blog-detail-view.tsx
+++ b/src/app/(public)/blog/[slug]/blog-detail-view.tsx
@@ -105,6 +105,10 @@ export function BlogDetailView({ slug }: { slug: string }) {
 	// Default reading time if not provided
 	const readingTime = `${blog.readingTime ?? 10} min read`;
 
+	// The latest-blogs list includes the article being viewed, so drop it before
+	// deciding whether the section has anything to show.
+	const relatedArticles = relatedBlogs.filter((related) => related.id !== blog.id).slice(0, 2);
+
 	return (
 		<div className="py-10">
 			<ReadingProgress value={readingProgress} />
@@ -151,16 +155,13 @@ export function BlogDetailView({ slug }: { slug: string }) {
 						</article>
 
 						{/* Related Articles */}
-						{relatedBlogs.length > 0 && (
+						{relatedArticles.length > 0 && (
 							<div className="mt-16 pt-8 border-t border-border animate-fade-in">
 								<h2 className="text-2xl font-bold mb-8">Related Articles</h2>
 								<div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-									{relatedBlogs
-										.filter((related) => related.id !== blog.id)
-										.slice(0, 2)
-										.map((relatedBlog) => (
-											<BlogCard key={relatedBlog.id} blog={relatedBlog} variant="compact" />
-										))}
+									{relatedArticles.map((relatedBlog) => (
+										<BlogCard key={relatedBlog.id} blog={relatedBlog} variant="compact" />
+									))}
 								</div>
 							</div>
 						)}

--- a/src/app/cms/availability/form/availability-form.tsx
+++ b/src/app/cms/availability/form/availability-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
 import {
 	ArrowRight,
 	Calendar,
@@ -36,7 +37,6 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
-import { queryClient } from "@/lib/query-client";
 import { availabilityService } from "@/services";
 
 // `month` is stored as 1-12; the Select shows full month names.
@@ -76,6 +76,7 @@ type AvailabilityFormValues = z.infer<typeof availabilitySchema>;
 
 export function AvailabilityForm() {
 	const router = useRouter();
+	const queryClient = useQueryClient();
 	const { id } = useParams<{ id?: string }>();
 	const isEditMode = Boolean(id);
 

--- a/src/app/cms/blogs/form/blog-form.tsx
+++ b/src/app/cms/blogs/form/blog-form.tsx
@@ -15,10 +15,10 @@ import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { useAuth } from "@/contexts/auth-context";
 import { calculateReadingTime } from "@/lib/mdx";
-import { queryClient } from "@/lib/query-client";
 import { slugify } from "@/lib/utils";
 import { type Blog, blogService, type NewBlog } from "@/services";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, Check, Clock, FileText, Info, Loader2, Save, Tag } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import { lazy, useEffect, useState } from "react";
@@ -42,6 +42,7 @@ type BlogFormValues = z.infer<typeof blogSchema>;
 export function BlogForm() {
 	const { user } = useAuth();
 	const router = useRouter();
+	const queryClient = useQueryClient();
 	const { id } = useParams<{ id?: string }>();
 	const isEditMode = Boolean(id);
 
@@ -163,7 +164,12 @@ export function BlogForm() {
 				toast.success("Blog post published successfully!");
 			}
 
-			queryClient.invalidateQueries({ queryKey: ["blogs", "latestBlogs"] });
+			// One key per call — a composite key is a single hierarchical key, not a list.
+			queryClient.invalidateQueries({ queryKey: ["blogs"] });
+			queryClient.invalidateQueries({ queryKey: ["blog"] });
+			queryClient.invalidateQueries({ queryKey: ["latestBlogs"] });
+			queryClient.invalidateQueries({ queryKey: ["relatedBlogs"] });
+			queryClient.invalidateQueries({ queryKey: ["blogTags"] });
 			router.push("/cms/blogs");
 		} catch (error) {
 			console.error("Error saving blog:", error);

--- a/src/app/cms/faqs/form/faqs-form.tsx
+++ b/src/app/cms/faqs/form/faqs-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, Check, HelpCircle, Info, ListOrdered, Loader2, Save } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -21,7 +22,6 @@ import {
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
-import { queryClient } from "@/lib/query-client";
 import { faqsService } from "@/services";
 
 const faqSchema = z.object({
@@ -35,6 +35,7 @@ type FaqFormValues = z.infer<typeof faqSchema>;
 
 export function FaqsForm() {
 	const router = useRouter();
+	const queryClient = useQueryClient();
 	const { id } = useParams<{ id?: string }>();
 	const isEditMode = Boolean(id);
 

--- a/src/app/cms/legal/[id]/page.tsx
+++ b/src/app/cms/legal/[id]/page.tsx
@@ -6,10 +6,10 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
-import { queryClient } from "@/lib/query-client";
 import { formatDate } from "@/lib/utils";
 import { sitePagesService } from "@/services";
 import type { SitePage } from "@/services/site-pages/types";
+import { useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, Loader2, Save } from "lucide-react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
@@ -21,6 +21,7 @@ const MDXEditor = lazy(() => import("@/components/mdx/mdx-editor"));
 
 export default function CmsLegalEditorPage() {
 	const router = useRouter();
+	const queryClient = useQueryClient();
 	const { id } = useParams<{ id: string }>();
 
 	const [page, setPage] = useState<SitePage | null>(null);

--- a/src/app/cms/offers/form/offers-form.tsx
+++ b/src/app/cms/offers/form/offers-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
 import {
 	ArrowRight,
 	Check,
@@ -37,7 +38,6 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { contentIconNames, getContentIcon } from "@/lib/icon-registry";
-import { queryClient } from "@/lib/query-client";
 import { offersService } from "@/services";
 
 // Prices are integer IDR, shown without decimals: "Rp5.000.000".
@@ -86,6 +86,7 @@ type OfferFormValues = z.infer<typeof offerSchema>;
 
 export function OffersForm() {
 	const router = useRouter();
+	const queryClient = useQueryClient();
 	const { id } = useParams<{ id?: string }>();
 	const isEditMode = Boolean(id);
 

--- a/src/app/cms/pages/[page]/page.tsx
+++ b/src/app/cms/pages/[page]/page.tsx
@@ -6,9 +6,9 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
-import { queryClient } from "@/lib/query-client";
 import { pageCopyService, siteSettingsService } from "@/services";
 import type { PageCopyContent, PageKey } from "@/services/page-copy/types";
+import { useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, Loader2, Save, Upload } from "lucide-react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
@@ -269,6 +269,7 @@ function Node({
 
 export default function CmsPageCopyEditor() {
 	const router = useRouter();
+	const queryClient = useQueryClient();
 	const { page } = useParams<{ page: string }>();
 	const [content, setContent] = useState<PageCopyContent | null>(null);
 	const [isLoading, setIsLoading] = useState(true);

--- a/src/app/cms/pricing/form/pricing-form.tsx
+++ b/src/app/cms/pricing/form/pricing-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, Check, Info, Loader2, Save, Settings2, Tag } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -21,7 +22,6 @@ import {
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
-import { queryClient } from "@/lib/query-client";
 import { pricingTiersService } from "@/services";
 
 const pricingSchema = z.object({
@@ -45,6 +45,7 @@ type PricingFormValues = z.infer<typeof pricingSchema>;
 
 export function PricingForm() {
 	const router = useRouter();
+	const queryClient = useQueryClient();
 	const { id } = useParams<{ id?: string }>();
 	const isEditMode = Boolean(id);
 

--- a/src/app/cms/process-steps/form/process-steps-form.tsx
+++ b/src/app/cms/process-steps/form/process-steps-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, Check, Info, Loader2, Save, Settings2, Workflow } from "lucide-react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -29,7 +30,6 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { contentIconNames, getContentIcon } from "@/lib/icon-registry";
-import { queryClient } from "@/lib/query-client";
 import { processStepsService, type ProcessScope } from "@/services";
 
 // Radix Select forbids empty-string values, so "no icon" travels as "none".
@@ -48,6 +48,7 @@ type ProcessStepFormValues = z.infer<typeof processStepSchema>;
 
 export function ProcessStepsForm() {
 	const router = useRouter();
+	const queryClient = useQueryClient();
 	const searchParams = useSearchParams();
 	const { id } = useParams<{ id?: string }>();
 	const isEditMode = Boolean(id);

--- a/src/app/cms/projects/form/project-form.tsx
+++ b/src/app/cms/projects/form/project-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
 import {
 	ArrowRight,
 	Briefcase,
@@ -35,7 +36,6 @@ import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { useAuth } from "@/contexts/auth-context";
 import { calculateReadingTime } from "@/lib/mdx";
-import { queryClient } from "@/lib/query-client";
 import { slugify } from "@/lib/utils";
 import { projectService, type TProjectResponse } from "@/services";
 
@@ -58,6 +58,7 @@ type ProjectFormValues = z.infer<typeof projectSchema>;
 export function ProjectForm() {
 	const { user } = useAuth();
 	const router = useRouter();
+	const queryClient = useQueryClient();
 	const { id } = useParams<{ id?: string }>();
 	const isEditMode = Boolean(id);
 
@@ -188,7 +189,12 @@ export function ProjectForm() {
 				toast.success("Project created successfully!");
 			}
 
-			queryClient.invalidateQueries({ queryKey: ["projects", "latestProjects"] });
+			// One key per call — a composite key is a single hierarchical key, not a list.
+			queryClient.invalidateQueries({ queryKey: ["projects"] });
+			queryClient.invalidateQueries({ queryKey: ["project"] });
+			queryClient.invalidateQueries({ queryKey: ["latestProjects"] });
+			queryClient.invalidateQueries({ queryKey: ["featuredProjects"] });
+			queryClient.invalidateQueries({ queryKey: ["projectTechnologies"] });
 			router.push("/cms/projects");
 		} catch (error) {
 			console.error("Error saving project:", error);

--- a/src/app/cms/resume/form/resume-form.tsx
+++ b/src/app/cms/resume/form/resume-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
 import {
 	ArrowRight,
 	Briefcase,
@@ -38,7 +39,6 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
-import { queryClient } from "@/lib/query-client";
 import { formatResumePeriod } from "@/lib/resume";
 import { resumeService, type ResumeKind } from "@/services";
 
@@ -75,6 +75,7 @@ type ResumeFormValues = z.infer<typeof resumeSchema>;
 
 export function ResumeForm() {
 	const router = useRouter();
+	const queryClient = useQueryClient();
 	const searchParams = useSearchParams();
 	const { id } = useParams<{ id?: string }>();
 	const isEditMode = Boolean(id);

--- a/src/app/cms/service-catalog/form/service-catalog-form.tsx
+++ b/src/app/cms/service-catalog/form/service-catalog-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
 import {
 	ArrowRight,
 	Check,
@@ -37,7 +38,6 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { contentIconNames, getContentIcon } from "@/lib/icon-registry";
-import { queryClient } from "@/lib/query-client";
 import { serviceCatalogService } from "@/services";
 
 const serviceCatalogSchema = z.object({
@@ -63,6 +63,7 @@ type ServiceCatalogFormValues = z.infer<typeof serviceCatalogSchema>;
 
 export function ServiceCatalogForm() {
 	const router = useRouter();
+	const queryClient = useQueryClient();
 	const { id } = useParams<{ id?: string }>();
 	const isEditMode = Boolean(id);
 

--- a/src/app/cms/site/page.tsx
+++ b/src/app/cms/site/page.tsx
@@ -17,7 +17,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { siteSettingsService } from "@/services";
 import type { SiteSettings } from "@/services/site-settings/types";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Contact, Globe, Layout, ListChecks, Loader2, Save } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -106,6 +106,7 @@ const toFormValues = (settings: SiteSettings): SiteFormValues => ({
 });
 
 export default function CmsSitePage() {
+	const queryClient = useQueryClient();
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
 	const { data: settings, isLoading } = useQuery({
@@ -176,6 +177,7 @@ export default function CmsSitePage() {
 				requestTimeframes: parseOptionLines(data.requestTimeframesText),
 				requestBudgetRanges: parseOptionLines(data.requestBudgetRangesText),
 			});
+			queryClient.invalidateQueries({ queryKey: ["cmsSiteSettings"] });
 			toast.success("Site settings saved — public pages update immediately");
 		} catch (error) {
 			console.error("Error saving site settings:", error);

--- a/src/app/cms/skills/form/skills-form.tsx
+++ b/src/app/cms/skills/form/skills-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, Check, Info, ListOrdered, Loader2, Save, Wrench } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -20,7 +21,6 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
-import { queryClient } from "@/lib/query-client";
 import { skillsService } from "@/services";
 
 const skillSchema = z.object({
@@ -33,6 +33,7 @@ type SkillFormValues = z.infer<typeof skillSchema>;
 
 export function SkillsForm() {
 	const router = useRouter();
+	const queryClient = useQueryClient();
 	const { id } = useParams<{ id?: string }>();
 	const isEditMode = Boolean(id);
 

--- a/src/app/cms/testimonials/form/testimonials-form.tsx
+++ b/src/app/cms/testimonials/form/testimonials-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, Check, Info, Loader2, Quote, Save, Star } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -28,7 +29,6 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
-import { queryClient } from "@/lib/query-client";
 import { testimonialsService } from "@/services";
 
 const testimonialSchema = z.object({
@@ -45,6 +45,7 @@ type TestimonialFormValues = z.infer<typeof testimonialSchema>;
 
 export function TestimonialsForm() {
 	const router = useRouter();
+	const queryClient = useQueryClient();
 	const { id } = useParams<{ id?: string }>();
 	const isEditMode = Boolean(id);
 

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -1,6 +1,10 @@
 import { API_CONFIG, APP_CONFIG } from "@/constants/app";
 import { QueryClient } from "@tanstack/react-query";
 
+// The only client is the one `Providers` mounts. Never export a module-level
+// instance from here: components importing it would invalidate a cache nothing
+// is subscribed to, so CMS lists would silently keep serving stale data.
+// Inside components, reach for the mounted client with `useQueryClient()`.
 export function makeQueryClient() {
 	return new QueryClient({
 		defaultOptions: {
@@ -16,5 +20,3 @@ export function makeQueryClient() {
 		},
 	});
 }
-
-export const queryClient = makeQueryClient();


### PR DESCRIPTION
## Summary

The module-level `queryClient` singleton exported from `src/lib/query-client.ts` was **not** the same instance mounted by `<QueryClientProvider>`. CMS form components importing it were calling `invalidateQueries` on an orphan cache that nothing was subscribed to, so list pages silently kept serving stale data after create/update mutations.

This PR replaces every direct import with the `useQueryClient()` hook so all invalidation targets the live, mounted cache. It also fixes a secondary issue in the blog detail page where the "Related Articles" section could show an empty heading.

## Changes

- **`refactor(query-client): use useQueryClient hook instead of module-level singleton`** (`2a82d63`)
  - Remove `export const queryClient` from `src/lib/query-client.ts`; add a doc comment explaining why
  - All 13 CMS form components + `cms/site/page.tsx`: replace `import { queryClient }` with `useQueryClient()` hook
  - `blog-form.tsx` & `project-form.tsx`: split composite `queryKey` arrays into individual `invalidateQueries` calls (one key per call)

- **`fix(blog-detail): extract relatedArticles filter before render`** (`b74005f`)
  - Extract `relatedBlogs.filter(...).slice(0, 2)` into a `relatedArticles` variable so the empty-check and the map use the same filtered list

## Test plan

- `npx tsc --noEmit` — passes with zero errors
- Working tree is clean after all commits