### PR TITLE
feat(site-settings): add blog module toggle and inline recaptcha disclaimer

### DIFF
--- a/src/app/(public)/blog/[slug]/page.tsx
+++ b/src/app/(public)/blog/[slug]/page.tsx
@@ -4,12 +4,17 @@ import { notFound } from "next/navigation";
 import { eq } from "drizzle-orm";
 
 import { getDb, schema } from "@/db";
-import { blogService } from "@/services";
+import { getCachedSiteSettings } from "@/lib/site-metadata";
+import { blogService, siteSettingsService } from "@/services";
 import { BlogDetailView } from "./blog-detail-view";
 
 type Params = { params: Promise<{ slug: string }> };
 
 export async function generateStaticParams() {
+	const settings = await siteSettingsService.get();
+	if (!settings.enableBlog) {
+		return [];
+	}
 	const rows = await getDb()
 		.select({ slug: schema.blogs.slug })
 		.from(schema.blogs)
@@ -18,7 +23,12 @@ export async function generateStaticParams() {
 }
 
 export async function generateMetadata({ params }: Params): Promise<Metadata> {
-	const { slug } = await params;
+	const [settings, { slug }] = await Promise.all([
+		getCachedSiteSettings(),
+		params,
+	]);
+	if (!settings.enableBlog) return { title: "Article not found" };
+
 	const blog = await blogService.getBySlug(slug);
 	if (!blog) return { title: "Article not found" };
 	return {
@@ -40,7 +50,12 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
 }
 
 export default async function BlogDetailPage({ params }: Params) {
-	const { slug } = await params;
+	const [settings, { slug }] = await Promise.all([
+		getCachedSiteSettings(),
+		params,
+	]);
+	if (!settings.enableBlog) notFound();
+
 	const blog = await blogService.getBySlug(slug);
 	if (!blog) notFound();
 	return <BlogDetailView slug={slug} />;

--- a/src/app/(public)/blog/page.tsx
+++ b/src/app/(public)/blog/page.tsx
@@ -1,9 +1,17 @@
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 
+import { getCachedSiteSettings } from "@/lib/site-metadata";
 import { pageCopyService } from "@/services";
 import { BlogView } from "./blog-view";
 
 export async function generateMetadata(): Promise<Metadata> {
+	const settings = await getCachedSiteSettings();
+	if (!settings.enableBlog) {
+		return {
+			title: "Page Not Found",
+		};
+	}
 	const copy = await pageCopyService.get("blog");
 	return {
 		title: copy?.meta.title ?? "Blog",
@@ -12,6 +20,10 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function BlogPage() {
+	const settings = await getCachedSiteSettings();
+	if (!settings.enableBlog) {
+		notFound();
+	}
 	const copy = await pageCopyService.get("blog");
 	return <BlogView copy={copy} />;
 }

--- a/src/app/(public)/contact/contact-view.tsx
+++ b/src/app/(public)/contact/contact-view.tsx
@@ -17,6 +17,7 @@ import { cn } from "@/lib/utils";
 import { ContactForm, contactService } from "@/services";
 import type { ContactCopy } from "@/services/page-copy/types";
 import type { SiteSettings } from "@/services/site-settings/types";
+import { RecaptchaDisclaimer } from "@/components/common/recaptcha-disclaimer";
 import { getReCaptchaToken } from "@/services/recaptcha";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation } from "@tanstack/react-query";
@@ -278,6 +279,8 @@ export const ContactView = ({ copy, settings }: ContactViewProps) => {
 												</>
 											)}
 										</Button>
+
+										<RecaptchaDisclaimer />
 									</form>
 								</Form>
 							</div>

--- a/src/app/(public)/hire-me/hire-me-view.tsx
+++ b/src/app/(public)/hire-me/hire-me-view.tsx
@@ -47,6 +47,7 @@ import type { Faq } from "@/services/faqs/types";
 import type { HireMeCopy } from "@/services/page-copy/types";
 import type { PricingTier } from "@/services/pricing-tiers/types";
 import type { ProcessStep } from "@/services/process-steps/types";
+import { RecaptchaDisclaimer } from "@/components/common/recaptcha-disclaimer";
 import { getReCaptchaToken } from "@/services/recaptcha";
 import type { ServiceItem } from "@/services/service-catalog/types";
 import type { SelectOption } from "@/services/site-settings/types";
@@ -841,6 +842,8 @@ export const HireMeView = ({
 											</>
 										)}
 									</Button>
+
+									<RecaptchaDisclaimer />
 								</form>
 							</Form>
 						</div>

--- a/src/app/(public)/home-view.tsx
+++ b/src/app/(public)/home-view.tsx
@@ -20,12 +20,14 @@ import Link from "next/link";
 type HomeViewProps = {
 	copy: HomeCopy | null;
 	services: ServiceItem[];
+	enableBlog?: boolean;
 };
 
-export function HomeView({ copy, services }: HomeViewProps) {
+export function HomeView({ copy, services, enableBlog = true }: HomeViewProps) {
 	const { data: blogs = [], isLoading: isBlogsLoading } = useQuery({
 		queryKey: ["latestBlogs"],
 		queryFn: () => blogService.getLatest(3),
+		enabled: enableBlog,
 	});
 
 	const { data: projects = [], isLoading: isProjectsLoading } = useQuery({
@@ -145,43 +147,45 @@ export function HomeView({ copy, services }: HomeViewProps) {
 					</div>
 				</section>
 
-				<section className="py-24">
-					<div className="container px-4 max-w-6xl mx-auto">
-						<SectionHeader
-							title={copy?.sections.blog.title}
-							subtitle={copy?.sections.blog.subtitle}
-							className="text-center mb-16"
-						/>
+				{enableBlog && (
+					<section className="py-24">
+						<div className="container px-4 max-w-6xl mx-auto">
+							<SectionHeader
+								title={copy?.sections.blog.title}
+								subtitle={copy?.sections.blog.subtitle}
+								className="text-center mb-16"
+							/>
 
-						<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-							{isBlogsLoading
-								? // Loading placeholders
-									Array.from({ length: 3 }).map((_, i) => (
-										<div key={i} className="bg-muted/30 h-[420px] rounded-xl animate-pulse" />
-									))
-								: blogs.map((blog, index) => (
-										<BlogCard
-											key={blog.id}
-											blog={blog}
-											className="animate-fade-in"
-											style={{ animationDelay: `${index * 0.1}s` }}
+							<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+								{isBlogsLoading
+									? // Loading placeholders
+										Array.from({ length: 3 }).map((_, i) => (
+											<div key={i} className="bg-muted/30 h-[420px] rounded-xl animate-pulse" />
+										))
+									: blogs.map((blog, index) => (
+											<BlogCard
+												key={blog.id}
+												blog={blog}
+												className="animate-fade-in"
+												style={{ animationDelay: `${index * 0.1}s` }}
+											/>
+										))}
+							</div>
+
+							<div className="mt-16 text-center">
+								<Button asChild variant="outline" size="lg" className="rounded-full px-8 group">
+									<Link href="/blog" className="hover:text-white">
+										View all articles
+										<ArrowRight
+											size={16}
+											className="ml-2 group-hover:translate-x-1 transition-transform"
 										/>
-									))}
+									</Link>
+								</Button>
+							</div>
 						</div>
-
-						<div className="mt-16 text-center">
-							<Button asChild variant="outline" size="lg" className="rounded-full px-8 group">
-								<Link href="/blog" className="hover:text-white">
-									View all articles
-									<ArrowRight
-										size={16}
-										className="ml-2 group-hover:translate-x-1 transition-transform"
-									/>
-								</Link>
-							</Button>
-						</div>
-					</div>
-				</section>
+					</section>
+				)}
 
 				<section className="py-24 relative overflow-hidden">
 					<div className="absolute inset-0 bg-gradient-to-r from-primary/5 via-transparent to-primary/5 pointer-events-none"></div>

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 
+import { getCachedSiteSettings } from "@/lib/site-metadata";
 import { pageCopyService, serviceCatalogService } from "@/services";
 import { HomeView } from "./home-view";
 
@@ -14,10 +15,17 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function HomePage() {
-	const [copy, services] = await Promise.all([
+	const [copy, services, settings] = await Promise.all([
 		pageCopyService.get("home"),
 		serviceCatalogService.getPublished(),
+		getCachedSiteSettings(),
 	]);
 
-	return <HomeView copy={copy} services={services.filter((service) => service.showOnHome)} />;
+	return (
+		<HomeView
+			copy={copy}
+			services={services.filter((service) => service.showOnHome)}
+			enableBlog={settings.enableBlog}
+		/>
+	);
 }

--- a/src/app/(public)/services/services-view.tsx
+++ b/src/app/(public)/services/services-view.tsx
@@ -36,6 +36,7 @@ import { serviceRequestService } from "@/services";
 import type { Faq } from "@/services/faqs/types";
 import type { ServicesCopy } from "@/services/page-copy/types";
 import type { ProcessStep } from "@/services/process-steps/types";
+import { RecaptchaDisclaimer } from "@/components/common/recaptcha-disclaimer";
 import { getReCaptchaToken } from "@/services/recaptcha";
 import type { ServiceItem } from "@/services/service-catalog/types";
 import type { SelectOption } from "@/services/site-settings/types";
@@ -495,6 +496,8 @@ export function ServicesView({
 											</>
 										)}
 									</Button>
+
+									<RecaptchaDisclaimer />
 								</form>
 							</Form>
 						</div>

--- a/src/app/cms/site/page.tsx
+++ b/src/app/cms/site/page.tsx
@@ -12,13 +12,14 @@ import {
 	FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { siteSettingsService } from "@/services";
 import type { SiteSettings } from "@/services/site-settings/types";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Contact, Globe, Layout, ListChecks, Loader2, Save } from "lucide-react";
+import { Contact, Globe, Layout, ListChecks, Loader2, Save, SlidersHorizontal } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -75,6 +76,7 @@ const siteFormSchema = z.object({
 	footerProjectLinksText: z.string(),
 	requestTimeframesText: z.string(),
 	requestBudgetRangesText: z.string(),
+	enableBlog: z.boolean(),
 });
 
 type SiteFormValues = z.infer<typeof siteFormSchema>;
@@ -103,6 +105,7 @@ const toFormValues = (settings: SiteSettings): SiteFormValues => ({
 	footerProjectLinksText: toPairLines(settings.footerProjectLinks, "link"),
 	requestTimeframesText: toPairLines(settings.requestTimeframes, "option"),
 	requestBudgetRangesText: toPairLines(settings.requestBudgetRanges, "option"),
+	enableBlog: settings.enableBlog ?? true,
 });
 
 export default function CmsSitePage() {
@@ -140,6 +143,7 @@ export default function CmsSitePage() {
 			footerProjectLinksText: "",
 			requestTimeframesText: "",
 			requestBudgetRangesText: "",
+			enableBlog: true,
 		},
 	});
 
@@ -176,6 +180,7 @@ export default function CmsSitePage() {
 				footerProjectLinks: parseLinkLines(data.footerProjectLinksText),
 				requestTimeframes: parseOptionLines(data.requestTimeframesText),
 				requestBudgetRanges: parseOptionLines(data.requestBudgetRangesText),
+				enableBlog: data.enableBlog,
 			});
 			queryClient.invalidateQueries({ queryKey: ["cmsSiteSettings"] });
 			toast.success("Site settings saved — public pages update immediately");
@@ -196,8 +201,12 @@ export default function CmsSitePage() {
 		);
 	}
 
+	type StringFieldKeys = {
+		[K in keyof SiteFormValues]: SiteFormValues[K] extends string ? K : never;
+	}[keyof SiteFormValues];
+
 	const textInput = (
-		name: keyof SiteFormValues,
+		name: StringFieldKeys,
 		label: string,
 		placeholder = "",
 		description?: string,
@@ -223,7 +232,7 @@ export default function CmsSitePage() {
 	);
 
 	const textArea = (
-		name: keyof SiteFormValues,
+		name: StringFieldKeys,
 		label: string,
 		rows: number,
 		description?: string,
@@ -270,6 +279,10 @@ export default function CmsSitePage() {
 								<Globe className="mr-2 h-4 w-4" />
 								Identity & SEO
 							</TabsTrigger>
+							<TabsTrigger value="features">
+								<SlidersHorizontal className="mr-2 h-4 w-4" />
+								Features
+							</TabsTrigger>
 							<TabsTrigger value="contact">
 								<Contact className="mr-2 h-4 w-4" />
 								Contact & Social
@@ -283,6 +296,41 @@ export default function CmsSitePage() {
 								Form Options
 							</TabsTrigger>
 						</TabsList>
+
+						<TabsContent value="features" className="mt-6">
+							<Card className="border-border/50 shadow-md rounded-xl">
+								<CardHeader>
+									<CardTitle>Site Features & Modules</CardTitle>
+									<CardDescription>
+										Control the visibility of public sections and pages without affecting CMS access
+									</CardDescription>
+								</CardHeader>
+								<CardContent className="space-y-6">
+									<FormField
+										control={form.control}
+										name="enableBlog"
+										render={({ field }) => (
+											<FormItem className="flex flex-row items-center justify-between rounded-lg border border-border/50 p-4 shadow-sm">
+												<div className="space-y-0.5 pr-4">
+													<FormLabel className="text-base font-medium text-foreground">
+														Enable Blog Module
+													</FormLabel>
+													<FormDescription>
+														When enabled, the /blog page, article previews on the home page, navigation links, and sitemap entries will be visible to public visitors. When disabled, the public pages return 404 while remaining fully editable in the CMS.
+													</FormDescription>
+												</div>
+												<FormControl>
+													<Switch
+														checked={field.value}
+														onCheckedChange={field.onChange}
+													/>
+												</FormControl>
+											</FormItem>
+										)}
+									/>
+								</CardContent>
+							</Card>
+						</TabsContent>
 
 						<TabsContent value="identity" className="mt-6">
 							<Card className="border-border/50 shadow-md rounded-xl">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -216,13 +216,7 @@
 	}
 }
 
-/* override google recaptcha */
+/* Hide floating Google reCAPTCHA badge (disclaimer is rendered on submit forms per Google policy) */
 .grecaptcha-badge {
-	width: 70px !important;
-	overflow: hidden !important;
-	transition: all 0.3s ease !important;
-	@apply !left-2 sm:!left-4 !bottom-2 sm:!bottom-4;
-}
-.grecaptcha-badge:hover {
-	width: 256px !important;
+	visibility: hidden !important;
 }

--- a/src/app/not-found-view.tsx
+++ b/src/app/not-found-view.tsx
@@ -8,7 +8,13 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect } from "react";
 
-export function NotFoundView({ copy }: { copy: NotFoundCopy }) {
+export function NotFoundView({
+	copy,
+	enableBlog = true,
+}: {
+	copy: NotFoundCopy;
+	enableBlog?: boolean;
+}) {
 	const pathname = usePathname();
 
 	useEffect(() => {
@@ -176,15 +182,19 @@ export function NotFoundView({ copy }: { copy: NotFoundCopy }) {
 							{ title: "Blog", path: "/blog" },
 							{ title: "Projects", path: "/projects" },
 							{ title: "About", path: "/about" },
-						].map((link) => (
-							<Link
-								key={link.path}
-								href={link.path}
-								className="px-4 py-2 rounded-lg bg-background/80 hover:bg-primary/10 border border-border text-center transition-colors"
-							>
-								{link.title}
-							</Link>
-						))}
+							{ title: "Services", path: "/services" },
+						]
+							.filter((link) => link.path !== "/blog" || enableBlog)
+							.slice(0, 3)
+							.map((link) => (
+								<Link
+									key={link.path}
+									href={link.path}
+									className="px-4 py-2 rounded-lg bg-background/80 hover:bg-primary/10 border border-border text-center transition-colors"
+								>
+									{link.title}
+								</Link>
+							))}
 					</div>
 				</div>
 			</motion.div>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,3 +1,4 @@
+import { getCachedSiteSettings } from "@/lib/site-metadata";
 import { pageCopyService } from "@/services";
 import type { NotFoundCopy } from "@/services/page-copy/types";
 import { NotFoundView } from "./not-found-view";
@@ -16,11 +17,17 @@ const FALLBACK: NotFoundCopy = {
 
 export default async function NotFound() {
 	let copy = FALLBACK;
+	let enableBlog = true;
 	try {
-		copy = (await pageCopyService.get("not-found")) ?? FALLBACK;
+		const [copyData, settings] = await Promise.all([
+			pageCopyService.get("not-found"),
+			getCachedSiteSettings(),
+		]);
+		if (copyData) copy = copyData;
+		if (settings) enableBlog = settings.enableBlog;
 	} catch {
 		// keep fallback
 	}
 
-	return <NotFoundView copy={copy} />;
+	return <NotFoundView copy={copy} enableBlog={enableBlog} />;
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,13 +3,16 @@ import type { MetadataRoute } from "next";
 
 import { getDb, schema } from "@/db";
 import { SITE_URL as BASE_URL } from "@/lib/site-url";
+import { siteSettingsService } from "@/services";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	const now = new Date();
+	const settings = await siteSettingsService.get();
+	const enableBlog = settings.enableBlog;
 
 	const staticPaths = [
 		"",
-		"/blog",
+		...(enableBlog ? ["/blog"] : []),
 		"/projects",
 		"/about",
 		"/services",
@@ -29,10 +32,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
 	const db = getDb();
 	const [blogRows, projectRows] = await Promise.all([
-		db
-			.select({ slug: schema.blogs.slug, updatedAt: schema.blogs.updatedAt })
-			.from(schema.blogs)
-			.where(eq(schema.blogs.isPublished, true)),
+		enableBlog
+			? db
+					.select({ slug: schema.blogs.slug, updatedAt: schema.blogs.updatedAt })
+					.from(schema.blogs)
+					.where(eq(schema.blogs.isPublished, true))
+			: Promise.resolve([]),
 		db
 			.select({ slug: schema.projects.slug, updatedAt: schema.projects.updatedAt })
 			.from(schema.projects)

--- a/src/components/common/recaptcha-disclaimer.tsx
+++ b/src/components/common/recaptcha-disclaimer.tsx
@@ -1,0 +1,31 @@
+import { cn } from "@/lib/utils";
+
+interface RecaptchaDisclaimerProps {
+	className?: string;
+}
+
+export function RecaptchaDisclaimer({ className }: RecaptchaDisclaimerProps) {
+	return (
+		<p className={cn("text-xs text-muted-foreground leading-relaxed", className)}>
+			This site is protected by reCAPTCHA and the Google{" "}
+			<a
+				href="https://policies.google.com/privacy"
+				target="_blank"
+				rel="noopener noreferrer"
+				className="underline hover:text-foreground transition-colors"
+			>
+				Privacy Policy
+			</a>{" "}
+			and{" "}
+			<a
+				href="https://policies.google.com/terms"
+				target="_blank"
+				rel="noopener noreferrer"
+				className="underline hover:text-foreground transition-colors"
+			>
+				Terms of Service
+			</a>{" "}
+			apply.
+		</p>
+	);
+}

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 import type { SiteSettings } from "@/services/site-settings/types";
 
-const navLinks = [
+const baseNavLinks = [
 	{ to: "/", label: "Home" },
 	{ to: "/blog", label: "Blog" },
 	{ to: "/projects", label: "Projects" },
@@ -14,6 +14,7 @@ const navLinks = [
 
 export const Footer = ({ settings }: { settings: SiteSettings }) => {
 	const currentYear = new Date().getFullYear();
+	const navLinks = baseNavLinks.filter((link) => link.to !== "/blog" || settings.enableBlog);
 
 	const socialLinks = [
 		{ href: settings.social.github, icon: Github, label: "GitHub" },

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -27,7 +27,12 @@ export const Layout = ({
 }: LayoutProps) => {
 	return (
 		<div className={cn("flex flex-col min-h-screen", className)}>
-			{!hideNavbar && <Navbar copyrightName={settings.copyrightName} />}
+			{!hideNavbar && (
+				<Navbar
+					copyrightName={settings.copyrightName}
+					enableBlog={settings.enableBlog}
+				/>
+			)}
 			<main className="flex-1 pt-20">{children}</main>
 			{!hideFooter && <Footer settings={settings} />}
 			<ScrollToTop />

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -10,7 +10,7 @@ import { useAuth } from "@/contexts/auth-context";
 import { useTheme } from "@/hooks/use-theme";
 import { cn } from "@/lib/utils";
 
-const navLinks = [
+const baseNavLinks = [
 	{ title: "Home", path: "/" },
 	{ title: "Blog", path: "/blog" },
 	{ title: "Projects", path: "/projects" },
@@ -20,7 +20,14 @@ const navLinks = [
 	{ title: "Contact", path: "/contact" },
 ];
 
-export const Navbar = ({ copyrightName = "Wisman Nur" }: { copyrightName?: string }) => {
+export const Navbar = ({
+	copyrightName = "Wisman Nur",
+	enableBlog = true,
+}: {
+	copyrightName?: string;
+	enableBlog?: boolean;
+}) => {
+	const navLinks = baseNavLinks.filter((link) => link.path !== "/blog" || enableBlog);
 	const [isOpen, setIsOpen] = useState(false);
 	const [isScrolled, setIsScrolled] = useState(false);
 	const pathname = usePathname();

--- a/src/db/migrations/0003_workable_harrier.sql
+++ b/src/db/migrations/0003_workable_harrier.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "site_settings" ADD COLUMN "enable_blog" boolean DEFAULT true NOT NULL;

--- a/src/db/migrations/meta/0003_snapshot.json
+++ b/src/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,1713 @@
+{
+  "id": "e0c099bb-d655-4bcb-a4e8-cbdbb5eee1c7",
+  "prevId": "7ab9285c-21d1-4ca0-a01d-ab106358d25e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.availability_slots": {
+      "name": "availability_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "availability_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Available'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blogs": {
+      "name": "blogs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published_date": {
+          "name": "published_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "likes": {
+          "name": "likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reading_time": {
+          "name": "reading_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blogs_slug_unique": {
+          "name": "blogs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "contact_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.faqs": {
+      "name": "faqs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.offers": {
+      "name": "offers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "for_who": {
+          "name": "for_who",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "extras": {
+          "name": "extras",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "is_popular": {
+          "name": "is_popular",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "offers_slug_unique": {
+          "name": "offers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_copy": {
+      "name": "page_copy",
+      "schema": "",
+      "columns": {
+        "page": {
+          "name": "page",
+          "type": "page_key",
+          "typeSchema": "public",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pricing_tiers": {
+      "name": "pricing_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_label": {
+          "name": "price_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "is_popular": {
+          "name": "is_popular",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cta_label": {
+          "name": "cta_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Get Started'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pricing_tiers_slug_unique": {
+          "name": "pricing_tiers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.process_steps": {
+      "name": "process_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "process_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published_date": {
+          "name": "published_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "technologies": {
+          "name": "technologies",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "demo_url": {
+          "name": "demo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "likes": {
+          "name": "likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reading_time": {
+          "name": "reading_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resume_entries": {
+      "name": "resume_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "resume_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization": {
+          "name": "organization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_current": {
+          "name": "is_current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_requests": {
+      "name": "service_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_type": {
+          "name": "service_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "budget": {
+          "name": "budget",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timeframe": {
+          "name": "timeframe",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_details": {
+          "name": "project_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "service_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "long_description": {
+          "name": "long_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_label": {
+          "name": "price_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "features": {
+          "name": "features",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "show_on_home": {
+          "name": "show_on_home",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_on_hire_me": {
+          "name": "show_on_hire_me",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "services_slug_unique": {
+          "name": "services_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.site_pages": {
+      "name": "site_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "site_pages_slug_unique": {
+          "name": "site_pages_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.site_settings": {
+      "name": "site_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'site'"
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_default": {
+          "name": "title_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_template": {
+          "name": "title_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "twitter_handle": {
+          "name": "twitter_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "theme_color": {
+          "name": "theme_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#4F46E5'"
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "og_tagline": {
+          "name": "og_tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "public_email": {
+          "name": "public_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "timezone_label": {
+          "name": "timezone_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "social": {
+          "name": "social",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footer_bio": {
+          "name": "footer_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "footer_tagline": {
+          "name": "footer_tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "copyright_name": {
+          "name": "copyright_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "repo_link_label": {
+          "name": "repo_link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "footer_project_links": {
+          "name": "footer_project_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "request_timeframes": {
+          "name": "request_timeframes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "request_budget_ranges": {
+          "name": "request_budget_ranges",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "enable_blog": {
+          "name": "enable_blog",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.testimonials": {
+      "name": "testimonials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_role": {
+          "name": "author_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "theme": {
+          "name": "theme",
+          "type": "theme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "color_scheme": {
+          "name": "color_scheme",
+          "type": "color_scheme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'blue'"
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "marketing_emails": {
+          "name": "marketing_emails",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "new_comment_notifications": {
+          "name": "new_comment_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "mention_notifications": {
+          "name": "mention_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asia/Jakarta'"
+        },
+        "date_format": {
+          "name": "date_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DD/MM/YYYY'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_uid_fk": {
+          "name": "user_settings_user_id_users_uid_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "social": {
+          "name": "social",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.availability_status": {
+      "name": "availability_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "limited",
+        "booked"
+      ]
+    },
+    "public.color_scheme": {
+      "name": "color_scheme",
+      "schema": "public",
+      "values": [
+        "blue",
+        "purple",
+        "green",
+        "orange",
+        "red"
+      ]
+    },
+    "public.contact_status": {
+      "name": "contact_status",
+      "schema": "public",
+      "values": [
+        "new",
+        "read",
+        "replied",
+        "archived"
+      ]
+    },
+    "public.page_key": {
+      "name": "page_key",
+      "schema": "public",
+      "values": [
+        "home",
+        "about",
+        "services",
+        "hire-me",
+        "offers",
+        "blog",
+        "projects",
+        "contact",
+        "not-found",
+        "default"
+      ]
+    },
+    "public.process_scope": {
+      "name": "process_scope",
+      "schema": "public",
+      "values": [
+        "services",
+        "hire-me"
+      ]
+    },
+    "public.resume_kind": {
+      "name": "resume_kind",
+      "schema": "public",
+      "values": [
+        "experience",
+        "education"
+      ]
+    },
+    "public.service_request_status": {
+      "name": "service_request_status",
+      "schema": "public",
+      "values": [
+        "new",
+        "in-progress",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.theme": {
+      "name": "theme",
+      "schema": "public",
+      "values": [
+        "light",
+        "dark",
+        "system"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1786077016047,
       "tag": "0002_numerous_trauma",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1787499995693,
+      "tag": "0003_workable_harrier",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -268,6 +268,7 @@ export const siteSettings = pgTable("site_settings", {
 		.$type<Array<{ id: string; label: string }>>()
 		.notNull()
 		.default(sql`'[]'::jsonb`),
+	enableBlog: boolean("enable_blog").notNull().default(true),
 	updatedAt: timestamp("updated_at", { withTimezone: true })
 		.notNull()
 		.defaultNow()

--- a/src/services/site-settings/actions.ts
+++ b/src/services/site-settings/actions.ts
@@ -48,6 +48,7 @@ const settingsUpdateSchema = z.object({
 	footerProjectLinks: z.array(labeledLinkSchema).optional(),
 	requestTimeframes: z.array(selectOptionSchema).optional(),
 	requestBudgetRanges: z.array(selectOptionSchema).optional(),
+	enableBlog: z.boolean().optional(),
 });
 
 export async function getSiteSettings(): Promise<SiteSettings> {

--- a/src/services/site-settings/defaults.ts
+++ b/src/services/site-settings/defaults.ts
@@ -51,5 +51,6 @@ export const DEFAULT_SITE_SETTINGS: SiteSettings = {
 		{ id: "10000-plus", label: "$ 10,000+" },
 		{ id: "hourly", label: "Hourly rate" },
 	],
+	enableBlog: true,
 	updatedAt: new Date(0),
 };

--- a/src/services/site-settings/types.ts
+++ b/src/services/site-settings/types.ts
@@ -38,6 +38,7 @@ export interface SiteSettings {
 	footerProjectLinks: LabeledLink[];
 	requestTimeframes: SelectOption[];
 	requestBudgetRanges: SelectOption[];
+	enableBlog: boolean;
 	updatedAt: Date;
 }
 


### PR DESCRIPTION
## Summary
Introduces a site setting switch (`enableBlog`) to toggle blog module visibility across the public site (navigation, home preview, direct routes, sitemap, not-found page) and adds inline reCAPTCHA terms/privacy disclaimer to submit forms while hiding the floating badge.

## Changes
- `feat(recaptcha): add inline disclaimer and hide badge on public forms`: Added inline `RecaptchaDisclaimer` component and hid the floating badge via CSS across contact, hire-me, and service request forms.
- `feat(site-settings): add enableBlog field and migration`: Added `enableBlog` boolean column to the `site_settings` schema, defaults, types, and drizzle migration.
- `feat(cms): add features tab to toggle blog module visibility`: Added a Features tab in CMS Site Settings to manage public visibility of the blog module.
- `feat(blog): hide blog links and return not found when disabled`: Respected `enableBlog` across navbar, footer, home page previews, `/blog` & `/blog/[slug]` route handlers (not found when disabled), sitemap generation, and not-found quick links.

## Test plan
- Run TypeScript check (`pnpm exec tsc --noEmit`): Passed with 0 errors.