### PR TITLE
feat(db): dynamic neon branch selection and dev runner script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 ```bash
-pnpm dev          # dev server on port 7000 (not 3000)
+pnpm dev          # dev server with Neon development DB (port 7000)
+pnpm dev --prod   # dev server with Neon production DB / main branch (alias: pnpm dev:prod)
 pnpm build        # runs drizzle-kit migrate FIRST, then next build — needs DATABASE_URL
 pnpm lint         # eslint
 pnpm exec tsc --noEmit   # typecheck (no test suite exists in this repo)
@@ -17,7 +18,7 @@ pnpm db:migrate   # apply migrations (needs DATABASE_URL in .env.local)
 pnpm db:studio    # browse the DB
 ```
 
-Environment lives in `.env.local` (never committed). Required: `DATABASE_URL`, `AUTH_SECRET`, `ADMIN_EMAIL`, `ADMIN_PASSWORD_HASH_B64`. The password hash is base64-encoded because bcrypt hashes contain `$`, which Next's env loader mangles via variable expansion. See README for the full list.
+Environment lives in `.env.local` (never committed). You can configure `DATABASE_URL` (or `DATABASE_URL_DEV` and `DATABASE_URL_PROD` for easy switching between Neon branches). Required: `DATABASE_URL`, `AUTH_SECRET`, `ADMIN_EMAIL`, `ADMIN_PASSWORD_HASH_B64`. The password hash is base64-encoded because bcrypt hashes contain `$`, which Next's env loader mangles via variable expansion. See README for the full list.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ pnpm db:migrate   # apply migrations from src/db/migrations
 ### 4. Run
 
 ```bash
-pnpm dev          # http://localhost:7000
+pnpm dev          # Run dev with Neon development database (http://localhost:7000)
+pnpm dev --prod   # Run dev connected to Neon production / main branch (or: pnpm dev:prod)
 ```
 
 Log in to the CMS at `/login` with the `ADMIN_EMAIL` / password you configured, then start filling in content.
@@ -109,7 +110,8 @@ Log in to the CMS at `/login` with the `ADMIN_EMAIL` / password you configured, 
 
 | Command | Description |
 | --- | --- |
-| `pnpm dev` | Dev server on port **7000** |
+| `pnpm dev` | Dev server with Neon development database (port **7000**) |
+| `pnpm dev --prod` | Dev server connected to Neon production / main database branch (alias: `pnpm dev:prod`) |
 | `pnpm build` | Runs pending DB migrations, then `next build` |
 | `pnpm start` | Serve the production build |
 | `pnpm lint` | ESLint |

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -2,7 +2,20 @@ import { config } from "dotenv";
 import { defineConfig } from "drizzle-kit";
 
 // Next.js loads .env.local itself; the drizzle-kit CLI does not.
+config({ path: ".env.production.local" });
 config({ path: ".env.local" });
+
+const isProd =
+	process.env.DB_ENV === "prod" || process.env.DB_ENV === "production";
+
+const dbUrl =
+	(isProd
+		? (process.env.DATABASE_URL_PROD ??
+			process.env.PROD_DATABASE_URL ??
+			process.env.DATABASE_URL)
+		: (process.env.DATABASE_URL_DEV ??
+			process.env.DEV_DATABASE_URL ??
+			process.env.DATABASE_URL)) ?? "";
 
 export default defineConfig({
 	schema: "./src/db/schema.ts",
@@ -10,6 +23,6 @@ export default defineConfig({
 	dialect: "postgresql",
 	dbCredentials: {
 		// Required for migrate/push/studio; `generate` works offline without it.
-		url: process.env.DATABASE_URL ?? "",
+		url: dbUrl,
 	},
 });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "node": "24.x"
   },
   "scripts": {
-    "dev": "next dev -p 7000",
+    "dev": "node scripts/dev.mjs",
+    "dev:prod": "node scripts/dev.mjs --prod",
     "build": "drizzle-kit migrate && next build",
     "start": "next start",
     "lint": "eslint",

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import dotenv from "dotenv";
+
+const rootDir = process.cwd();
+
+// Check if --prod or --production flag is passed in CLI args or DB_ENV
+const args = process.argv.slice(2);
+const isProd =
+	args.includes("--prod") ||
+	args.includes("--production") ||
+	process.env.DB_ENV === "prod" ||
+	process.env.DB_ENV === "production";
+
+// Filter out our custom flags before passing the rest to `next dev`
+const forwardedArgs = args.filter(
+	(arg) => arg !== "--prod" && arg !== "--production",
+);
+
+// If user didn't specify a port in args, default to port 7000
+if (!forwardedArgs.includes("-p") && !forwardedArgs.includes("--port")) {
+	forwardedArgs.push("-p", "7000");
+}
+
+/**
+ * Load .env files in priority order for the given target environment
+ */
+function loadEnvironment(targetProd) {
+	// Base env files
+	const envFiles = targetProd
+		? [
+				".env.production.local",
+				".env.local",
+				".env.production",
+				".env",
+			]
+		: [
+				".env.development.local",
+				".env.local",
+				".env.development",
+				".env",
+			];
+
+	// Load files into process.env if they exist
+	for (const file of envFiles) {
+		const filePath = path.join(rootDir, file);
+		if (fs.existsSync(filePath)) {
+			const envConfig = dotenv.parse(fs.readFileSync(filePath));
+			for (const k in envConfig) {
+				if (!process.env[k]) {
+					process.env[k] = envConfig[k];
+				}
+			}
+		}
+	}
+
+	// Suffix-based variable resolution within single .env.local
+	if (targetProd) {
+		process.env.DB_ENV = "prod";
+		process.env.NEXT_PUBLIC_DB_ENV = "prod";
+
+		const prodUrl =
+			process.env.DATABASE_URL_PROD ||
+			process.env.POSTGRES_URL ||
+			process.env.PROD_DATABASE_URL ||
+			process.env.DATABASE_URL_PRODUCTION ||
+			process.env.NEON_DATABASE_URL_PROD;
+
+		if (prodUrl) {
+			process.env.DATABASE_URL = prodUrl;
+		}
+
+		const prodUnpooled =
+			process.env.DATABASE_URL_UNPOOLED_PROD ||
+			process.env.POSTGRES_URL_NON_POOLING ||
+			process.env.PROD_DATABASE_URL_UNPOOLED ||
+			process.env.POSTGRES_URL_NON_POOLING_PROD;
+		if (prodUnpooled) {
+			process.env.DATABASE_URL_UNPOOLED = prodUnpooled;
+		}
+
+		const prodPostgresUrl =
+			process.env.POSTGRES_URL_PROD ||
+			process.env.POSTGRES_URL ||
+			process.env.PROD_POSTGRES_URL;
+		if (prodPostgresUrl) {
+			process.env.POSTGRES_URL = prodPostgresUrl;
+		}
+	} else {
+		process.env.DB_ENV = "dev";
+		process.env.NEXT_PUBLIC_DB_ENV = "dev";
+
+		const devUrl =
+			process.env.DATABASE_URL_DEV ||
+			process.env.DEV_DATABASE_URL ||
+			process.env.DATABASE_URL_DEVELOPMENT ||
+			process.env.NEON_DATABASE_URL_DEV;
+
+		if (devUrl) {
+			process.env.DATABASE_URL = devUrl;
+		}
+
+		const devUnpooled =
+			process.env.DATABASE_URL_UNPOOLED_DEV ||
+			process.env.DEV_DATABASE_URL_UNPOOLED;
+		if (devUnpooled) {
+			process.env.DATABASE_URL_UNPOOLED = devUnpooled;
+		}
+	}
+}
+
+loadEnvironment(isProd);
+
+// Helper to mask credentials for safe terminal logging
+function maskDbUrl(dbUrl) {
+	if (!dbUrl) return "NOT CONFIGURED";
+	try {
+		const parsed = new URL(dbUrl);
+		const auth = parsed.username
+			? `${parsed.username}:••••••••@`
+			: "";
+		return `${parsed.protocol}//${auth}${parsed.host}${parsed.pathname}`;
+	} catch {
+		return "Valid URL (hidden for security)";
+	}
+}
+
+// Visual indicator in console
+const cyan = "\x1b[36m";
+const green = "\x1b[32m";
+const yellow = "\x1b[33m";
+const red = "\x1b[31m";
+const bold = "\x1b[1m";
+const reset = "\x1b[0m";
+
+const targetLabel = isProd
+	? `${red}${bold}[ PRODUCTION / MAIN BRANCH ] ⚠️ CAUTION${reset}`
+	: `${green}${bold}[ DEVELOPMENT BRANCH ]${reset}`;
+
+console.log(`\n${cyan}┌─────────────────────────────────────────────────────────────┐${reset}`);
+console.log(`${cyan}│${reset}  ${bold}Neon DB Environment Selector${reset}                              ${cyan}│${reset}`);
+console.log(`${cyan}├─────────────────────────────────────────────────────────────┤${reset}`);
+console.log(`${cyan}│${reset}  Target DB: ${targetLabel}`);
+console.log(`${cyan}│${reset}  Endpoint : ${yellow}${maskDbUrl(process.env.DATABASE_URL)}${reset}`);
+if (isProd) {
+	console.log(`${cyan}│${reset}  ${red}Note     : Any CMS edits will affect LIVE PRODUCTION data!${reset}  ${cyan}│${reset}`);
+}
+console.log(`${cyan}└─────────────────────────────────────────────────────────────┘\n${reset}`);
+
+if (isProd && !process.env.DATABASE_URL_PROD && !process.env.DATABASE_URL) {
+	console.error(
+		`${red}Error: No production database URL found!${reset}\n` +
+			`Please set ${bold}DATABASE_URL_PROD${reset} in your ${bold}.env.local${reset} or create a ${bold}.env.production.local${reset} file.\n`,
+	);
+	process.exit(1);
+}
+
+// Spawn `next dev`
+const nextBin = path.join(rootDir, "node_modules", ".bin", "next");
+const child = spawn(nextBin, ["dev", ...forwardedArgs], {
+	stdio: "inherit",
+	env: process.env,
+	shell: process.platform === "win32",
+});
+
+child.on("exit", (code, signal) => {
+	if (signal) {
+		process.kill(process.pid, signal);
+	} else {
+		process.exit(code ?? 0);
+	}
+});
+
+process.on("SIGINT", () => {
+	child.kill("SIGINT");
+});
+
+process.on("SIGTERM", () => {
+	child.kill("SIGTERM");
+});

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -19,7 +19,22 @@ import * as schema from "./schema";
 let _db: ReturnType<typeof createDb> | null = null;
 
 function createDb() {
-	const url = process.env.DATABASE_URL;
+	const isProd =
+		process.env.DB_ENV === "prod" ||
+		process.env.DB_ENV === "production" ||
+		process.env.NEXT_PUBLIC_DB_ENV === "prod";
+
+	const url = isProd
+		? (process.env.DATABASE_URL_PROD ||
+			process.env.POSTGRES_URL ||
+			process.env.PROD_DATABASE_URL ||
+			process.env.DATABASE_URL_PRODUCTION ||
+			process.env.DATABASE_URL)
+		: (process.env.DATABASE_URL_DEV ||
+			process.env.DEV_DATABASE_URL ||
+			process.env.DATABASE_URL_DEVELOPMENT ||
+			process.env.DATABASE_URL);
+
 	if (!url) {
 		throw new Error(
 			"DATABASE_URL is not set. Run `vercel env pull .env.local` to fetch it from the Neon⇄Vercel integration.",


### PR DESCRIPTION
## Summary
Adds a custom Next.js dev server runner script and dynamic Neon database URL resolution based on the environment mode. This enables running the local dev server seamlessly with either the development Neon database branch (`pnpm dev`) or the production / main branch (`pnpm dev --prod` / `pnpm dev:prod`).

## Changes
- `feat(db)`: Update `src/db/index.ts` and `drizzle.config.ts` to dynamically resolve `DATABASE_URL_PROD` / `POSTGRES_URL` when `DB_ENV=prod`, and `DATABASE_URL_DEV` / `DATABASE_URL` when in development mode.
- `feat(scripts)`: Add `scripts/dev.mjs` runner with clear visual status banner indicating target database environment and endpoint, and add `dev:prod` script alias in `package.json`.
- `docs`: Update `README.md` and `CLAUDE.md` to document the `pnpm dev --prod` / `pnpm dev:prod` commands and database URL options.

## Test plan
- Run `pnpm dev --help` and verified dev banner points to development Neon branch.
- Run `pnpm dev:prod --help` and verified prod banner points to production Neon branch.
- Executed `pnpm exec tsc --noEmit` (passed cleanly with 0 errors).
- Tested database connections against both dev and production branches.