### PR TITLE
feat(analytics): comprehensive umami public page tracking and auth route isolation

### DIFF
--- a/src/app/(public)/contact/contact-view.tsx
+++ b/src/app/(public)/contact/contact-view.tsx
@@ -228,6 +228,7 @@ export const ContactView = ({ copy, settings }: ContactViewProps) => {
 									<Button
 										type="submit"
 										size="lg"
+										data-umami-event="contact-form-submit-click"
 										className="w-full md:w-auto px-8 rounded-full shadow-lg shadow-primary/20 group"
 										disabled={mutation.isPending || isSubmitting}
 									>

--- a/src/app/(public)/hire-me/hire-me-view.tsx
+++ b/src/app/(public)/hire-me/hire-me-view.tsx
@@ -218,6 +218,7 @@ export function HireMeView({
 						<div className="flex flex-wrap gap-3.5 justify-center animate-fade-in">
 							<Button
 								size="lg"
+								data-umami-event="hire-me-start-project-hero-click"
 								className="rounded-full px-7 h-12 text-xs md:text-sm font-semibold shadow-lg shadow-primary/25 hover:shadow-primary/35 hover:scale-[1.02] active:scale-[0.98] transition-all duration-200 group"
 								onClick={() => {
 									const contactForm = document.getElementById("contact-form");
@@ -233,6 +234,7 @@ export function HireMeView({
 							<Button
 								variant="outline"
 								size="lg"
+								data-umami-event="hire-me-view-packages-click"
 								className="rounded-full px-7 h-12 text-xs md:text-sm font-semibold border-border/60 bg-card/70 backdrop-blur-sm hover:bg-primary/10 hover:border-primary/40 hover:text-primary shadow-sm hover:shadow-md hover:scale-[1.02] active:scale-[0.98] transition-all duration-300 group"
 								onClick={() => {
 									const servicesSection = document.getElementById("services-section");
@@ -295,7 +297,7 @@ export function HireMeView({
 								</div>
 
 								<Button size="lg" className="rounded-full px-8 w-full md:w-auto shadow-md" asChild>
-									<Link href="/contact">
+									<Link href="/contact" data-umami-event="hire-me-direct-contact-click">
 										<MessageSquare size={16} className="mr-2" />
 										Direct Contact
 									</Link>
@@ -322,16 +324,23 @@ export function HireMeView({
 						className="text-center mb-14"
 					/>
 
-					<Tabs defaultValue="services" className="w-full" onValueChange={setActiveTab}>
+					<Tabs defaultValue="services" className="w-full" onValueChange={(val) => {
+						setActiveTab(val);
+						trackEvent("hire-me-tab-change", { tab: val });
+					}}>
 						<TabsList className="grid w-full max-w-xs mx-auto grid-cols-2 mb-12 p-1 bg-muted/60 rounded-full border border-border/40">
 							<TabsTrigger
 								value="services"
+								data-umami-event="hire-me-tab-click"
+								data-umami-event-tab="services"
 								className="rounded-full text-xs font-semibold data-[state=active]:bg-primary data-[state=active]:text-primary-foreground"
 							>
 								Packages
 							</TabsTrigger>
 							<TabsTrigger
 								value="expertise"
+								data-umami-event="hire-me-tab-click"
+								data-umami-event-tab="expertise"
 								className="rounded-full text-xs font-semibold data-[state=active]:bg-primary data-[state=active]:text-primary-foreground"
 							>
 								Expertise
@@ -385,6 +394,8 @@ export function HireMeView({
 													variant={isSelected ? "default" : "outline"}
 													className="w-full rounded-xl text-xs font-semibold h-10"
 													onClick={() => handleServiceSelect(tier.slug)}
+													data-umami-event="hire-me-select-package-click"
+													data-umami-event-package={tier.slug}
 												>
 													{tier.ctaLabel || "Select Package"}
 												</Button>
@@ -764,6 +775,7 @@ export function HireMeView({
 								<Button
 									type="submit"
 									size="lg"
+									data-umami-event="hire-me-form-submit-click"
 									className="w-full md:w-auto px-8 rounded-full shadow-lg shadow-primary/20 group"
 									disabled={mutation.isPending || isSubmitting}
 								>

--- a/src/app/(public)/home-view.tsx
+++ b/src/app/(public)/home-view.tsx
@@ -176,7 +176,11 @@ export function HomeView({ copy, services, enableBlog = true }: HomeViewProps) {
 								<div className="mt-5 pt-3.5 border-t border-border/40 flex items-center justify-between">
 									<span className="text-xs text-muted-foreground">Ready to collaborate?</span>
 									<Button asChild variant="ghost" size="sm" className="text-xs text-primary font-semibold p-0 hover:bg-transparent">
-										<Link href="/hire-me" className="flex items-center gap-1">
+										<Link
+											href="/hire-me"
+											data-umami-event="home-engineering-book-slot-click"
+											className="flex items-center gap-1"
+										>
 											Book a slot <ArrowRight size={13} />
 										</Link>
 									</Button>
@@ -234,7 +238,13 @@ export function HomeView({ copy, services, enableBlog = true }: HomeViewProps) {
 										<div className="pt-3.5 border-t border-border/40 flex items-center justify-between">
 											<span className="text-xs font-semibold text-primary">{service.priceLabel}</span>
 											<Button asChild variant="ghost" size="sm" className="text-xs text-muted-foreground hover:text-primary p-0">
-												<Link href="/services">Learn more →</Link>
+												<Link
+													href="/services"
+													data-umami-event="home-service-learn-more-click"
+													data-umami-event-service={service.slug || service.title}
+												>
+													Learn more →
+												</Link>
 											</Button>
 										</div>
 									)}

--- a/src/app/(public)/services/services-view.tsx
+++ b/src/app/(public)/services/services-view.tsx
@@ -221,6 +221,8 @@ export function ServicesView({
 											variant={isSelected ? "default" : "outline"}
 											className="w-full rounded-xl text-xs font-semibold h-10"
 											onClick={() => handleServiceSelect(service.slug)}
+											data-umami-event="services-card-select-click"
+											data-umami-event-service={service.slug}
 										>
 											{isSelected ? "Selected for Inquiry" : "Select Service"}
 										</Button>
@@ -482,6 +484,7 @@ export function ServicesView({
 								<Button
 									type="submit"
 									size="lg"
+									data-umami-event="services-form-submit-click"
 									className="w-full md:w-auto px-8 rounded-full shadow-lg shadow-primary/20 group"
 									disabled={mutation.isPending || isSubmitting}
 								>

--- a/src/app/cv/cv-view.tsx
+++ b/src/app/cv/cv-view.tsx
@@ -135,9 +135,7 @@ export function CVView({ user, experiences, education, skills, settings }: CVVie
 	const toggleTheme = () => {
 		const nextTheme = isDark ? "light" : "dark";
 		setTheme(nextTheme);
-		if (typeof window !== "undefined" && window.umami) {
-			window.umami.track("theme-toggle", { theme: nextTheme, source: "cv-page" });
-		}
+		trackEvent("theme-toggle", { theme: nextTheme, source: "cv-page" });
 	};
 
 	const handlePrint = () => {
@@ -204,7 +202,7 @@ export function CVView({ user, experiences, education, skills, settings }: CVVie
 							size="sm"
 							className="rounded-full text-xs text-muted-foreground hover:text-primary font-medium px-3 h-9 hidden sm:inline-flex"
 						>
-							<Link href="/about">About</Link>
+							<Link href="/about" data-umami-event="cv-about-click">About</Link>
 						</Button>
 						<Button
 							asChild
@@ -212,7 +210,7 @@ export function CVView({ user, experiences, education, skills, settings }: CVVie
 							size="sm"
 							className="rounded-full text-xs text-muted-foreground hover:text-primary font-medium px-3 h-9 hidden sm:inline-flex"
 						>
-							<Link href="/projects">Projects</Link>
+							<Link href="/projects" data-umami-event="cv-projects-click">Projects</Link>
 						</Button>
 					</div>
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,8 @@ import { getCachedSiteSettings } from "@/lib/site-metadata";
 import { SITE_URL } from "@/lib/site-url";
 import { Providers } from "./providers";
 
+import { UmamiAnalytics } from "@/components/analytics/umami-analytics";
+
 const RECAPTCHA_SITE_KEY = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
 const UMAMI_WEBSITE_ID = process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID;
 const UMAMI_SCRIPT_URL =
@@ -74,13 +76,10 @@ export default function RootLayout({
 		<html lang="en" className={inter.variable} suppressHydrationWarning>
 			<body className="font-sans antialiased">
 				<Providers>{children}</Providers>
-				{UMAMI_WEBSITE_ID && (
-					<Script
-						src={UMAMI_SCRIPT_URL}
-						data-website-id={UMAMI_WEBSITE_ID}
-						strategy="afterInteractive"
-					/>
-				)}
+				<UmamiAnalytics
+					websiteId={UMAMI_WEBSITE_ID}
+					scriptUrl={UMAMI_SCRIPT_URL}
+				/>
 				{RECAPTCHA_SITE_KEY && (
 					<Script
 						src={`https://www.google.com/recaptcha/api.js?render=${RECAPTCHA_SITE_KEY}`}

--- a/src/app/not-found-view.tsx
+++ b/src/app/not-found-view.tsx
@@ -97,13 +97,13 @@ export function NotFoundView({
 						variants={itemVariants}
 					>
 						<Button asChild size="lg" className="rounded-full">
-							<Link href="/" className="flex items-center gap-2">
+							<Link href="/" data-umami-event="not-found-home-click" className="flex items-center gap-2">
 								<Home size={16} />
 								{copy.primaryLabel}
 							</Link>
 						</Button>
 						<Button asChild variant="outline" size="lg" className="rounded-full">
-							<Link href="/contact" className="flex items-center gap-2">
+							<Link href="/contact" data-umami-event="not-found-contact-click" className="flex items-center gap-2">
 								{copy.secondaryLabel}
 								<ArrowRight size={16} />
 							</Link>
@@ -190,6 +190,8 @@ export function NotFoundView({
 								<Link
 									key={link.path}
 									href={link.path}
+									data-umami-event="not-found-quick-link-click"
+									data-umami-event-label={link.title}
 									className="px-4 py-2 rounded-lg bg-background/80 hover:bg-primary/10 border border-border text-center transition-colors"
 								>
 									{link.title}

--- a/src/components/analytics/umami-analytics.tsx
+++ b/src/components/analytics/umami-analytics.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { Suspense, useEffect, useRef } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import Script from "next/script";
+import { isTrackingAllowed, trackEvent, trackPageView } from "@/lib/umami";
+
+interface UmamiAnalyticsProps {
+	websiteId?: string;
+	scriptUrl?: string;
+}
+
+function UmamiRouteTracker() {
+	const pathname = usePathname();
+	const searchParams = useSearchParams();
+	const prevPathRef = useRef<string | null>(null);
+
+	// Pageview tracking on public route changes
+	useEffect(() => {
+		if (!pathname) return;
+
+		const fullUrl = searchParams?.toString()
+			? `${pathname}?${searchParams.toString()}`
+			: pathname;
+
+		if (prevPathRef.current === fullUrl) return;
+		prevPathRef.current = fullUrl;
+
+		if (isTrackingAllowed(pathname)) {
+			const timer = setTimeout(() => {
+				trackPageView(fullUrl, document.title);
+			}, 100);
+			return () => clearTimeout(timer);
+		}
+	}, [pathname, searchParams]);
+
+	// Global click listener for data-umami-event attributes on public pages
+	useEffect(() => {
+		const handleClick = (e: MouseEvent) => {
+			if (!isTrackingAllowed(window.location.pathname)) return;
+
+			const target = (e.target as HTMLElement)?.closest?.("[data-umami-event]");
+			if (!target) return;
+
+			const eventName = target.getAttribute("data-umami-event");
+			if (!eventName) return;
+
+			const dataset = (target as HTMLElement).dataset;
+			const eventData: Record<string, string> = {};
+
+			for (const key in dataset) {
+				if (key.startsWith("umamiEvent") && key !== "umamiEvent") {
+					const dataKey = key.replace(/^umamiEvent/, "");
+					const formattedKey = dataKey.charAt(0).toLowerCase() + dataKey.slice(1);
+					const val = dataset[key];
+					if (val !== undefined) {
+						eventData[formattedKey] = val;
+					}
+				}
+			}
+
+			trackEvent(eventName, eventData);
+		};
+
+		document.addEventListener("click", handleClick, { capture: true });
+		return () => {
+			document.removeEventListener("click", handleClick, { capture: true });
+		};
+	}, []);
+
+	return null;
+}
+
+export function UmamiAnalytics({
+	websiteId = process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID,
+	scriptUrl = process.env.NEXT_PUBLIC_UMAMI_SCRIPT_URL || "https://cloud.umami.is/script.js",
+}: UmamiAnalyticsProps) {
+	const pathname = usePathname();
+
+	const handleScriptLoad = () => {
+		if (typeof window !== "undefined" && window.umami) {
+			const originalTrack = window.umami.track;
+			if (typeof originalTrack === "function") {
+				window.umami.track = (...args: TAny[]) => {
+					if (!isTrackingAllowed(window.location.pathname)) {
+						// Strictly block Umami tracking on auth and CMS routes
+						return;
+					}
+					return originalTrack.apply(window.umami, args);
+				};
+			}
+
+			// Initial page view if on public path
+			if (pathname && isTrackingAllowed(pathname)) {
+				trackPageView(window.location.pathname, document.title);
+			}
+		}
+	};
+
+	if (!websiteId) return null;
+
+	return (
+		<>
+			<Script
+				src={scriptUrl}
+				data-website-id={websiteId}
+				data-auto-track="false"
+				strategy="afterInteractive"
+				onLoad={handleScriptLoad}
+			/>
+			<Suspense fallback={null}>
+				<UmamiRouteTracker />
+			</Suspense>
+		</>
+	);
+}

--- a/src/components/auth/protected-route.tsx
+++ b/src/components/auth/protected-route.tsx
@@ -2,8 +2,7 @@
 
 import { LoadingOverlay } from "@/components/ui/loading-overlay";
 import { useAuth } from "@/contexts/auth-context";
-import { trackEvent } from "@/lib/umami";
-import { usePathname, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 
 interface ProtectedRouteProps {
@@ -22,18 +21,7 @@ export const ProtectedRoute = ({
 	redirectPath = "/login",
 }: ProtectedRouteProps) => {
 	const { user, loading: isLoading, error } = useAuth();
-	const pathname = usePathname();
 	const router = useRouter();
-
-	// Track unauthorized access attempts
-	useEffect(() => {
-		if (requireAuth && !user && !isLoading) {
-			trackEvent("unauthorized_access_attempt", {
-				path: pathname,
-				timestamp: new Date().toISOString(),
-			});
-		}
-	}, [user, isLoading, pathname, requireAuth]);
 
 	// Perform redirects as a side-effect once auth has resolved.
 	useEffect(() => {

--- a/src/components/common/command-palette.tsx
+++ b/src/components/common/command-palette.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/components/ui/command";
 import { useTheme } from "@/hooks/use-theme";
 import { toast } from "@/components/ui/use-toast";
+import { trackEvent } from "@/lib/umami";
 import { blogService, projectService } from "@/services";
 import type { Blog } from "@/services/blog/types";
 import type { Project } from "@/services/project/types";
@@ -89,14 +90,18 @@ export function CommandPalette({
 		}
 	}, [open, projects.length, blogs.length, enableBlog]);
 
-	const runCommand = React.useCallback((command: () => void) => {
+	const runCommand = React.useCallback((command: () => void, label?: string) => {
 		setOpen(false);
+		if (label) {
+			trackEvent("command-palette-select", { label });
+		}
 		command();
 	}, []);
 
 	const copyEmail = () => {
 		navigator.clipboard.writeText(publicEmail);
 		setHasCopied(true);
+		trackEvent("command-palette-copy-email", { email: publicEmail });
 		toast({
 			title: "Email copied to clipboard!",
 			description: publicEmail,
@@ -117,11 +122,13 @@ export function CommandPalette({
 					<CommandItem
 						onSelect={() =>
 							runCommand(() => {
-								setTheme(isDark ? "light" : "dark");
+								const nextTheme = isDark ? "light" : "dark";
+								setTheme(nextTheme);
+								trackEvent("theme-toggle", { theme: nextTheme, source: "command-palette" });
 								toast({
-									title: `Switched to ${isDark ? "Light" : "Dark"} mode`,
+									title: `Switched to ${nextTheme === "light" ? "Light" : "Dark"} mode`,
 								});
-							})
+							}, "Toggle Theme")
 						}
 					>
 						{isDark ? (
@@ -137,7 +144,7 @@ export function CommandPalette({
 						onSelect={() =>
 							runCommand(() => {
 								copyEmail();
-							})
+							}, "Copy Email")
 						}
 					>
 						{hasCopied ? (
@@ -152,7 +159,7 @@ export function CommandPalette({
 						onSelect={() =>
 							runCommand(() => {
 								router.push("/hire-me");
-							})
+							}, "Hire Me")
 						}
 					>
 						<Sparkles className="mr-2 h-4 w-4 text-amber-500 animate-pulse" />
@@ -168,7 +175,7 @@ export function CommandPalette({
 						onSelect={() =>
 							runCommand(() => {
 								router.push("/");
-							})
+							}, "Nav: Home")
 						}
 					>
 						<Home className="mr-2 h-4 w-4 text-muted-foreground" />
@@ -180,7 +187,7 @@ export function CommandPalette({
 							onSelect={() =>
 								runCommand(() => {
 									router.push("/blog");
-								})
+								}, "Nav: Blog")
 							}
 						>
 							<BookOpen className="mr-2 h-4 w-4 text-muted-foreground" />
@@ -192,7 +199,7 @@ export function CommandPalette({
 						onSelect={() =>
 							runCommand(() => {
 								router.push("/projects");
-							})
+							}, "Nav: Projects")
 						}
 					>
 						<FolderGit2 className="mr-2 h-4 w-4 text-muted-foreground" />
@@ -203,7 +210,7 @@ export function CommandPalette({
 						onSelect={() =>
 							runCommand(() => {
 								router.push("/services");
-							})
+							}, "Nav: Services")
 						}
 					>
 						<Briefcase className="mr-2 h-4 w-4 text-muted-foreground" />
@@ -214,7 +221,7 @@ export function CommandPalette({
 						onSelect={() =>
 							runCommand(() => {
 								router.push("/about");
-							})
+							}, "Nav: About")
 						}
 					>
 						<User className="mr-2 h-4 w-4 text-muted-foreground" />
@@ -225,7 +232,7 @@ export function CommandPalette({
 						onSelect={() =>
 							runCommand(() => {
 								router.push("/cv");
-							})
+							}, "Nav: CV")
 						}
 					>
 						<FileText className="mr-2 h-4 w-4 text-muted-foreground" />
@@ -236,7 +243,7 @@ export function CommandPalette({
 						onSelect={() =>
 							runCommand(() => {
 								router.push("/contact");
-							})
+							}, "Nav: Contact")
 						}
 					>
 						<Mail className="mr-2 h-4 w-4 text-muted-foreground" />
@@ -247,7 +254,7 @@ export function CommandPalette({
 						onSelect={() =>
 							runCommand(() => {
 								router.push("/login");
-							})
+							}, "Nav: Login")
 						}
 					>
 						<ShieldCheck className="mr-2 h-4 w-4 text-muted-foreground" />
@@ -266,7 +273,7 @@ export function CommandPalette({
 									onSelect={() =>
 										runCommand(() => {
 											router.push(`/projects/${project.slug}`);
-										})
+										}, `Project: ${project.title}`)
 									}
 								>
 									<Code2 className="mr-2 h-4 w-4 text-primary" />
@@ -291,7 +298,7 @@ export function CommandPalette({
 									onSelect={() =>
 										runCommand(() => {
 											router.push(`/blog/${blog.slug}`);
-										})
+										}, `Blog: ${blog.title}`)
 									}
 								>
 									<BookOpen className="mr-2 h-4 w-4 text-primary" />

--- a/src/components/detail/newsletter-signup.tsx
+++ b/src/components/detail/newsletter-signup.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { SpotlightCard } from "@/components/ui/spotlight-card";
 import { Mail, Sparkles, Check } from "lucide-react";
 import { toast } from "@/components/ui/use-toast";
+import { trackEvent } from "@/lib/umami";
 
 const NewsletterSignup = () => {
 	const [email, setEmail] = useState("");
@@ -18,10 +19,13 @@ const NewsletterSignup = () => {
 				title: "Please enter a valid email",
 				variant: "destructive",
 			});
+			trackEvent("newsletter-subscribe-error", { reason: "invalid_email" });
 			return;
 		}
 
+		trackEvent("newsletter-subscribe-attempt");
 		setIsSubmitted(true);
+		trackEvent("newsletter-subscribe-success");
 		toast({
 			title: "Subscribed successfully!",
 			description: "Thanks for joining. You will receive new updates.",
@@ -59,6 +63,7 @@ const NewsletterSignup = () => {
 				/>
 				<Button
 					type="submit"
+					data-umami-event="newsletter-subscribe-click"
 					className="w-full h-9 rounded-xl text-xs font-semibold shadow-sm"
 					disabled={isSubmitted}
 				>

--- a/src/components/home/hero-terminal.tsx
+++ b/src/components/home/hero-terminal.tsx
@@ -70,6 +70,8 @@ On branch main (100% test passing) 🚀`,
 					<button
 						type="button"
 						onClick={() => setActiveTab("config")}
+						data-umami-event="hero-terminal-tab-click"
+						data-umami-event-tab="config"
 						className={cn(
 							"px-2.5 py-1 rounded-md text-xs transition-colors flex items-center gap-1.5",
 							activeTab === "config"
@@ -84,6 +86,8 @@ On branch main (100% test passing) 🚀`,
 					<button
 						type="button"
 						onClick={() => setActiveTab("terminal")}
+						data-umami-event="hero-terminal-tab-click"
+						data-umami-event-tab="terminal"
 						className={cn(
 							"px-2.5 py-1 rounded-md text-xs transition-colors flex items-center gap-1.5",
 							activeTab === "terminal"
@@ -98,6 +102,8 @@ On branch main (100% test passing) 🚀`,
 					<button
 						type="button"
 						onClick={() => setActiveTab("stack")}
+						data-umami-event="hero-terminal-tab-click"
+						data-umami-event-tab="stack"
 						className={cn(
 							"px-2.5 py-1 rounded-md text-xs transition-colors flex items-center gap-1.5",
 							activeTab === "stack"
@@ -115,6 +121,8 @@ On branch main (100% test passing) 🚀`,
 					type="button"
 					onClick={handleCopy}
 					aria-label="Copy snippet"
+					data-umami-event="hero-terminal-copy-click"
+					data-umami-event-tab={activeTab}
 					className="p-1.5 rounded-md hover:bg-[#21262d] text-gray-400 hover:text-gray-200 transition-colors"
 				>
 					{hasCopied ? <Check size={14} className="text-green-400" /> : <Copy size={14} />}

--- a/src/components/home/tech-stack-bento.tsx
+++ b/src/components/home/tech-stack-bento.tsx
@@ -82,6 +82,8 @@ export function TechStackBento() {
 								key={cat.id}
 								type="button"
 								onClick={() => setActiveCategory(cat.id)}
+								data-umami-event="home-tech-category-click"
+								data-umami-event-category={cat.id}
 								className={cn(
 									"flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium transition-all duration-200",
 									isActive

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -293,11 +293,19 @@ export const Footer = ({ settings }: { settings: SiteSettings }) => {
 					</div>
 
 					<div className="flex items-center gap-3 text-xs">
-						<Link href="/privacy-policy" className="hover:text-primary transition-colors">
+						<Link
+							href="/privacy-policy"
+							data-umami-event="footer-privacy-policy-click"
+							className="hover:text-primary transition-colors"
+						>
 							Privacy Policy
 						</Link>
 						<span>•</span>
-						<Link href="/terms-of-service" className="hover:text-primary transition-colors">
+						<Link
+							href="/terms-of-service"
+							data-umami-event="footer-terms-of-service-click"
+							className="hover:text-primary transition-colors"
+						>
 							Terms of Service
 						</Link>
 						{settings.repoUrl && (

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { openCommandPalette } from "@/components/common/command-palette";
 import { useAuth } from "@/contexts/auth-context";
 import { useTheme } from "@/hooks/use-theme";
+import { trackEvent } from "@/lib/umami";
 import { cn } from "@/lib/utils";
 
 const baseNavLinks = [
@@ -72,9 +73,7 @@ export const Navbar = ({
 	const toggleTheme = () => {
 		const nextTheme = isDark ? "light" : "dark";
 		setTheme(nextTheme);
-		if (typeof window !== "undefined" && window.umami) {
-			window.umami.track("theme-toggle", { theme: nextTheme });
-		}
+		trackEvent("theme-toggle", { theme: nextTheme, source: "navbar" });
 	};
 
 	return (

--- a/src/components/site-pages/site-page-view.tsx
+++ b/src/components/site-pages/site-page-view.tsx
@@ -38,7 +38,7 @@ export function SitePageView({ title, lastUpdatedLabel, content, icon }: SitePag
 		<div className="container max-w-4xl mx-auto py-16 px-4">
 			<div className="flex items-center gap-2 mb-8">
 				<Button variant="ghost" size="sm" asChild className="rounded-full">
-					<Link href="/" className="flex items-center gap-2">
+					<Link href="/" data-umami-event="legal-back-home-click" className="flex items-center gap-2">
 						<ArrowLeft size={16} />
 						Back to Home
 					</Link>

--- a/src/features/blog/blog-filters.tsx
+++ b/src/features/blog/blog-filters.tsx
@@ -44,6 +44,7 @@ const BlogFilters = ({
 						<button
 							type="button"
 							onClick={() => setSearchTerm("")}
+							data-umami-event="blog-filter-clear-search"
 							className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
 							aria-label="Clear search"
 						>
@@ -95,6 +96,7 @@ const BlogFilters = ({
 							<button
 								type="button"
 								onClick={() => setSearchTerm("")}
+								data-umami-event="blog-filter-clear-search-chip"
 								className="ml-1.5 hover:text-red-500"
 								aria-label="Clear search filter"
 							>
@@ -108,6 +110,8 @@ const BlogFilters = ({
 							<button
 								type="button"
 								onClick={() => setSelectedTag(null)}
+								data-umami-event="blog-filter-clear-tag-chip"
+								data-umami-event-tag={selectedTag}
 								className="ml-1.5 hover:text-red-500"
 								aria-label="Clear tag filter"
 							>
@@ -121,6 +125,7 @@ const BlogFilters = ({
 							setSearchTerm("");
 							setSelectedTag(null);
 						}}
+						data-umami-event="blog-filter-clear-all"
 						className="text-primary hover:underline ml-2 font-medium"
 					>
 						Clear all

--- a/src/features/project/project-filters.tsx
+++ b/src/features/project/project-filters.tsx
@@ -69,6 +69,8 @@ const ProjectFilters = ({
 							<button
 								type="button"
 								onClick={() => setSelectedTech(null)}
+								data-umami-event="project-filter-clear-tech"
+								data-umami-event-tech={selectedTech}
 								className="ml-1.5 hover:text-red-500"
 								aria-label="Clear tech filter"
 							>
@@ -82,6 +84,7 @@ const ProjectFilters = ({
 							setSearchTerm("");
 							setSelectedTech(null);
 						}}
+						data-umami-event="project-filter-reset"
 						className="text-primary hover:underline ml-2 font-medium"
 					>
 						Reset

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -1,14 +1,82 @@
-// Custom event tracking for Umami Analytics.
+// Custom event tracking and route management for Umami Analytics.
 // In development without an Umami script loaded, it logs to the dev console.
 // When window.umami is available, it dispatches the event.
+
+/**
+ * Checks if a given pathname is a public page where tracking is allowed.
+ * Returns false for auth pages (/login), CMS admin pages (/cms), and API routes.
+ */
+export function isTrackingAllowed(pathname?: string): boolean {
+	if (typeof window === "undefined" && !pathname) return false;
+	const currentPath = pathname ?? (typeof window !== "undefined" ? window.location.pathname : "");
+	if (!currentPath) return false;
+
+	const normalized = currentPath.toLowerCase();
+
+	// Explicitly block auth and CMS routes
+	if (
+		normalized === "/login" ||
+		normalized.startsWith("/login/") ||
+		normalized === "/cms" ||
+		normalized.startsWith("/cms/") ||
+		normalized.startsWith("/api/")
+	) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Tracks custom events to Umami Analytics if on a public page.
+ * Strictly prevents tracking on auth / CMS pages.
+ */
 export const trackEvent = (
 	eventName: string,
 	eventData?: Record<string, string | number | boolean | null | undefined>,
 ) => {
-	if (typeof window !== "undefined" && window.umami) {
+	if (typeof window === "undefined") return;
+
+	// Prevent tracking on auth / cms pages
+	if (!isTrackingAllowed(window.location.pathname)) {
+		return;
+	}
+
+	if (window.umami) {
 		window.umami.track(eventName, eventData as Record<string, TAny>);
 	} else if (process.env.NODE_ENV !== "production") {
 		console.log(`[Analytics DEV] ${eventName}:`, eventData ?? {});
 	}
 };
+
+/**
+ * Tracks pageviews to Umami Analytics for public pages.
+ * Strictly prevents tracking on auth / CMS pages.
+ */
+export const trackPageView = (url?: string, title?: string) => {
+	if (typeof window === "undefined") return;
+
+	const pathname = url ?? window.location.pathname;
+	if (!isTrackingAllowed(pathname)) {
+		return;
+	}
+
+	if (window.umami) {
+		if (url) {
+			window.umami.track((props) => ({
+				...props,
+				url,
+				title: title ?? (typeof document !== "undefined" ? document.title : undefined),
+			}));
+		} else {
+			window.umami.track();
+		}
+	} else if (process.env.NODE_ENV !== "production") {
+		console.log(`[Analytics DEV PageView]:`, {
+			url: pathname,
+			title: title ?? (typeof document !== "undefined" ? document.title : undefined),
+		});
+	}
+};
+
 


### PR DESCRIPTION
## Summary
- Implemented comprehensive Umami event tracking across all public pages, modals, filters, and interactive widgets.
- Prevented and isolated Umami analytics tracking from running on authentication (`/login`) and CMS admin routes (`/cms/*`).
- Replaced global automatic pageview tracking with a path-filtered Umami tracker component.

## Changes
- `feat(analytics): add route-guarded umami tracker and path filtering`: Created `UmamiAnalytics` component with `data-auto-track="false"`, pathname filtering, and auto click delegation for `data-umami-event` elements.
- `refactor(auth): remove analytics tracking from auth route guard`: Removed unauthorized access tracking from `ProtectedRoute`.
- `feat(tracking): add interactive event tracking across public pages`: Added missing `data-umami-event` attributes and event dispatches across Navbar, Footer, Command Palette, Home widgets, Project & Blog filters, Newsletter signup, Services, Hire Me, Contact, Legal pages, CV, and 404 views.

## Test plan
- Ran `npx tsc --noEmit` -> TypeScript checks passed with 0 errors.
- Ran `npx next build` -> Successfully generated and validated all 62 static and dynamic routes.
- Verified that visiting `/login` or `/cms/*` does not send tracking beacons to Umami.