### PR TITLE
fix(inbox): sync inbound email replies via resend receiving api

### DIFF
--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,13 +5,13 @@
       "source": "neondatabase/agent-skills",
       "sourceType": "github",
       "skillPath": "skills/neon/SKILL.md",
-      "computedHash": "34714c04b6ab06adc728df602131f8c23fcbf79bf6a54c4b82e9021ad138cb72"
+      "computedHash": "a008e354dade553f451dd1d8a33872cdeb8d3ff8ea1efbc3f561c7f3119c760a"
     },
     "neon-postgres": {
       "source": "neondatabase/agent-skills",
       "sourceType": "github",
       "skillPath": "skills/neon-postgres/SKILL.md",
-      "computedHash": "7985b983f8ae5e36d88b82bcc2f3353726d22ced9be97d438681b308afed509e"
+      "computedHash": "9386efb7f97bd96f01d0c84f467e8e6e41be54f73cc1ece9c92f4f1dbd76f10f"
     }
   }
 }

--- a/src/app/api/webhooks/resend-inbound/route.ts
+++ b/src/app/api/webhooks/resend-inbound/route.ts
@@ -1,23 +1,28 @@
 import { NextRequest, NextResponse } from "next/server";
 import { desc, eq } from "drizzle-orm";
+import { Resend } from "resend";
 import { Webhook } from "svix";
 
 import { getDb, schema } from "@/db";
 import { sendInboundAlertToAdmin } from "@/services/core/resend";
 
 const { contacts, serviceRequests, inquiryMessages } = schema;
+const resendApiKey = process.env.RESEND_API_KEY;
+const resend = resendApiKey ? new Resend(resendApiKey) : null;
 
-function extractCleanEmail(rawFrom: string): { name: string; email: string } {
-	const match = rawFrom.match(/(.*?)\s*<([^>]+)>/);
+function extractCleanEmail(rawFrom: unknown): { name: string; email: string } {
+	const fromStr =
+		Array.isArray(rawFrom) ? String(rawFrom[0] || "") : typeof rawFrom === "string" ? rawFrom : "";
+	const match = fromStr.match(/(.*?)\s*<([^>]+)>/);
 	if (match) {
 		return {
 			name: match[1]?.trim() || match[2]?.trim() || "Client",
-			email: match[2]?.trim() || rawFrom.trim(),
+			email: match[2]?.trim() || fromStr.trim(),
 		};
 	}
 	return {
-		name: rawFrom.split("@")[0] || "Client",
-		email: rawFrom.trim(),
+		name: fromStr.split("@")[0] || "Client",
+		email: fromStr.trim(),
 	};
 }
 
@@ -25,6 +30,23 @@ function extractInquiryId(subject: string): string | null {
 	// Look for pattern [Ref: #ID] or [Ref: ID]
 	const match = subject.match(/\[Ref:\s*#?([a-zA-Z0-9_-]+)\]/i);
 	return match ? match[1].trim() : null;
+}
+
+function htmlToPlainText(html: string): string {
+	return html
+		.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "")
+		.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "")
+		.replace(/<br\s*[\/]?>/gi, "\n")
+		.replace(/<\/p>/gi, "\n\n")
+		.replace(/<\/div>/gi, "\n")
+		.replace(/<[^>]+>/g, "")
+		.replace(/&nbsp;/g, " ")
+		.replace(/&amp;/g, "&")
+		.replace(/&lt;/g, "<")
+		.replace(/&gt;/g, ">")
+		.replace(/&quot;/g, '"')
+		.replace(/&#39;/g, "'")
+		.trim();
 }
 
 function cleanReplyBody(text: string): string {
@@ -57,6 +79,7 @@ export async function POST(req: NextRequest) {
 			const svixSignature = req.headers.get("svix-signature");
 
 			if (!svixId || !svixTimestamp || !svixSignature) {
+				console.error("[Resend Inbound] Missing Svix headers while RESEND_WEBHOOK_SECRET is set");
 				return NextResponse.json({ error: "Missing Svix headers" }, { status: 400 });
 			}
 
@@ -68,22 +91,50 @@ export async function POST(req: NextRequest) {
 					"svix-signature": svixSignature,
 				});
 			} catch (err) {
-				console.error("Invalid webhook signature:", err);
+				console.error("[Resend Inbound] Invalid webhook signature:", err);
 				return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
 			}
 		}
 
 		const body = JSON.parse(rawPayload);
 
-		// Handle both Resend standard webhook payload and direct inbound formats
+		// Handle Resend standard webhook payload (e.g. type: "email.received")
 		const data = body.data || body;
-		const fromRaw = data.from || "";
-		const subject = data.subject || "(No Subject)";
-		const textContent = cleanReplyBody(data.text || data.html || "");
+		let fromRaw = data.from || "";
+		let subject = data.subject || "(No Subject)";
+		let rawText = data.text || "";
+		let rawHtml = data.html || "";
+
+		// Resend's email.received webhook payload only contains metadata (email_id).
+		// We fetch the full body content via Resend Receiving API.
+		const emailId = data.email_id || data.id;
+		if (!rawText && !rawHtml && emailId && resend) {
+			try {
+				const { data: fullEmail, error } = await resend.emails.receiving.get(emailId);
+				if (error) {
+					console.error("[Resend Inbound] Failed to fetch email from Resend API:", error);
+				} else if (fullEmail) {
+					if (fullEmail.from) fromRaw = fullEmail.from;
+					if (fullEmail.subject) subject = fullEmail.subject;
+					if (fullEmail.text) rawText = fullEmail.text;
+					if (fullEmail.html) rawHtml = fullEmail.html;
+				}
+			} catch (err) {
+				console.error("[Resend Inbound] Error calling resend.emails.receiving.get:", err);
+			}
+		}
+
+		let textContent = "";
+		if (rawText) {
+			textContent = cleanReplyBody(rawText);
+		} else if (rawHtml) {
+			textContent = cleanReplyBody(htmlToPlainText(rawHtml));
+		}
 
 		const { name: senderName, email: senderEmail } = extractCleanEmail(fromRaw);
 
 		if (!senderEmail || !textContent) {
+			console.warn("[Resend Inbound] Incomplete email payload skipped. senderEmail:", senderEmail, "hasContent:", !!textContent);
 			return NextResponse.json({ message: "Incomplete email payload, skipped" }, { status: 200 });
 		}
 
@@ -182,11 +233,15 @@ export async function POST(req: NextRequest) {
 				subject: targetSubject,
 				message: textContent,
 			});
+
+			console.log(`[Resend Inbound] Successfully linked message to inquiry ${targetInquiryId} (${targetInquiryType}) from ${senderEmail}`);
+		} else {
+			console.warn(`[Resend Inbound] Inbound email received but no matching inquiry found for sender: ${senderEmail}, subject: ${subject}`);
 		}
 
 		return NextResponse.json({ success: true, matched: !!targetInquiryId });
 	} catch (error) {
-		console.error("Error processing inbound email webhook:", error);
+		console.error("[Resend Inbound] Error processing inbound email webhook:", error);
 		return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
 	}
 }

--- a/src/components/common/command-palette.tsx
+++ b/src/components/common/command-palette.tsx
@@ -14,7 +14,6 @@ import {
 	Moon,
 	Copy,
 	Check,
-	ShieldCheck,
 	Code2,
 	FileText,
 } from "lucide-react";
@@ -248,17 +247,6 @@ export function CommandPalette({
 					>
 						<Mail className="mr-2 h-4 w-4 text-muted-foreground" />
 						<span>Contact Me</span>
-					</CommandItem>
-
-					<CommandItem
-						onSelect={() =>
-							runCommand(() => {
-								router.push("/login");
-							}, "Nav: Login")
-						}
-					>
-						<ShieldCheck className="mr-2 h-4 w-4 text-muted-foreground" />
-						<span>Admin Login / CMS</span>
 					</CommandItem>
 				</CommandGroup>
 

--- a/src/services/contacts/actions.ts
+++ b/src/services/contacts/actions.ts
@@ -77,7 +77,7 @@ export async function submit(formData: ContactForm, recaptchaToken?: string): Pr
 		.values({ ...clean, status: "new" })
 		.returning({ id: contacts.id });
 
-	await sendContactEmails(clean);
+	await sendContactEmails({ ...clean, id });
 
 	return id;
 }

--- a/src/services/core/resend.ts
+++ b/src/services/core/resend.ts
@@ -25,6 +25,7 @@ const SENDER_HI =
 	"Wisman Nur <hi@wismannur.pro>";
 
 interface ContactEmailPayload {
+	id?: string;
 	name: string;
 	email: string;
 	subject: string;
@@ -32,6 +33,7 @@ interface ContactEmailPayload {
 }
 
 interface ServiceRequestEmailPayload {
+	id?: string;
 	name: string;
 	email: string;
 	company?: string;
@@ -71,6 +73,7 @@ export async function sendContactEmails(payload: ContactEmailPayload): Promise<v
 
 	try {
 		const sentAt = new Date().toLocaleString("id-ID", { timeZone: "Asia/Jakarta" });
+		const refTag = payload.id ? `[Ref: #${payload.id}]` : `[Ref: #${payload.subject}]`;
 
 		await Promise.allSettled([
 			// 1. Notification to Admin
@@ -93,7 +96,7 @@ export async function sendContactEmails(payload: ContactEmailPayload): Promise<v
 				from: SENDER_HI,
 				to: payload.email,
 				replyTo: "hi@wismannur.pro",
-				subject: `[Ref: #${payload.subject}] Pesan Anda telah diterima - Wisman Nur`,
+				subject: `${refTag} Pesan Anda telah diterima - Wisman Nur`,
 				react: ClientContactAutoReplyEmail({
 					name: payload.name,
 					subject: payload.subject,
@@ -118,6 +121,7 @@ export async function sendServiceRequestEmails(payload: ServiceRequestEmailPaylo
 
 	try {
 		const sentAt = new Date().toLocaleString("id-ID", { timeZone: "Asia/Jakarta" });
+		const refTag = payload.id ? `[Ref: #${payload.id}]` : `[Ref: #${payload.serviceType}]`;
 
 		await Promise.allSettled([
 			// 1. Notification to Admin
@@ -143,7 +147,7 @@ export async function sendServiceRequestEmails(payload: ServiceRequestEmailPaylo
 				from: SENDER_HI,
 				to: payload.email,
 				replyTo: "hi@wismannur.pro",
-				subject: `[Ref: #${payload.serviceType}] Permintaan proyek diterima - Wisman Nur`,
+				subject: `${refTag} Permintaan proyek diterima - Wisman Nur`,
 				react: ClientServiceRequestAutoReplyEmail({
 					name: payload.name,
 					serviceType: payload.serviceType,

--- a/src/services/service-requests/actions.ts
+++ b/src/services/service-requests/actions.ts
@@ -85,7 +85,7 @@ export async function submit(data: NewServiceRequest, recaptchaToken?: string): 
 		.values({ ...clean, status: "new" })
 		.returning({ id: serviceRequests.id });
 
-	await sendServiceRequestEmails(clean);
+	await sendServiceRequestEmails({ ...clean, id });
 
 	return id;
 }


### PR DESCRIPTION
## Summary
- **Resend Inbound Receiving**: Fetch full email content using `resend.emails.receiving.get(emailId)` in the webhook handler to retrieve email body (`text` / `html`) which is not bundled by default in Resend's `email.received` webhook payload.
- **HTML Parsing & Cleanup**: Clean quote footers and transform HTML content into clean plaintext before saving to `inquiry_messages`.
- **Accurate Ref Tagging**: Pass the record `id` into `sendContactEmails` and `sendServiceRequestEmails` so auto-reply emails include `[Ref: #ID]` for reliable thread reconciliation.
- **Command Palette**: Remove unused admin login entry.

## Verification
- `npx tsc --noEmit` passed with zero errors.
- Verified thread resolution logic across contact inquiries and service requests.