### PR TITLE
feat(email): support rfc 5322 threading headers and robust inbound matching

### DIFF
--- a/src/app/api/webhooks/resend-inbound/route.ts
+++ b/src/app/api/webhooks/resend-inbound/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { and, desc, eq, gte, sql } from "drizzle-orm";
+import { and, desc, eq, gte, or, sql } from "drizzle-orm";
 import { Resend } from "resend";
 import { Webhook } from "svix";
 
@@ -257,6 +257,13 @@ export async function POST(req: NextRequest) {
 					? (emailHeaders["X-Entity-Ref-ID"] as string)
 					: null;
 
+		const inboundMessageId =
+			(typeof emailHeaders["message-id"] === "string" ? (emailHeaders["message-id"] as string) : undefined) ||
+			(typeof emailHeaders["Message-ID"] === "string" ? (emailHeaders["Message-ID"] as string) : undefined) ||
+			(typeof fullEmail?.message_id === "string" ? (fullEmail.message_id as string) : undefined) ||
+			(typeof data.message_id === "string" ? (data.message_id as string) : undefined) ||
+			(emailId ? emailId : undefined);
+
 		const rawExplicitRefId =
 			toInfo.id ||
 			headerRefId ||
@@ -268,6 +275,24 @@ export async function POST(req: NextRequest) {
 			(toInfo.type && toInfo.type !== "job_outreach" ? toInfo.type : undefined) || "contact";
 		let targetSubject = subject;
 		let foundEntity = false;
+
+		const referencedMessageIds = (function() {
+			const inReplyTo = String(emailHeaders["in-reply-to"] || emailHeaders["In-Reply-To"] || fullEmail?.in_reply_to || "");
+			const refs = String(emailHeaders["references"] || emailHeaders["References"] || fullEmail?.references || "");
+			const combined = `${inReplyTo} ${refs}`.trim();
+			if (!combined) return [];
+			const bracketMatches = combined.match(/<([^>]+)>/g);
+			if (bracketMatches && bracketMatches.length > 0) {
+				return bracketMatches.map(b => b.replace(/[<>]/g, "").trim().toLowerCase()).filter(Boolean);
+			}
+			return combined.split(/\s+/).map(s => s.replace(/[<>]/g, "").trim().toLowerCase()).filter(Boolean);
+		})();
+
+		// Helper to normalize subject strings for comparison
+		const normalizeSubject = (str: string) =>
+			str.replace(/^(?:re|fwd|fw):\s*/gi, "").replace(/\s+/g, " ").trim().toLowerCase();
+
+		const isReplyOrFwd = /^(?:re|fwd|fw):/i.test(subject.trim());
 
 		// 5. Match by explicit reference ID if found
 		if (targetInquiryId) {
@@ -309,6 +334,7 @@ export async function POST(req: NextRequest) {
 					senderName: senderName || outreachRow.contactName || "Recruiter",
 					senderEmail,
 					message: textContent,
+					messageId: inboundMessageId || null,
 				});
 
 				await db
@@ -327,6 +353,7 @@ export async function POST(req: NextRequest) {
 					clientEmail: senderEmail,
 					subject: outreachRow.subject,
 					message: textContent,
+					isNewConversation: false,
 				});
 
 				console.log(
@@ -398,154 +425,186 @@ export async function POST(req: NextRequest) {
 			);
 		}
 
-		// 6. Fallback: match by sender email with most recent entity (outreach or inquiry) only if no explicit Ref ID was present
-		if (!targetInquiryId && senderEmail) {
+		// 6. Match by threading headers (In-Reply-To / References) if no explicit Ref ID was present
+		if (!targetInquiryId && referencedMessageIds.length > 0) {
+			// Check if any referenced ID matches a known job outreach
+			for (const refId of referencedMessageIds) {
+				// Strip domain for Resend ID matching if needed
+				const cleanRef = refId.split("@")[0];
+				const [matchedOutreachMsg] = await db
+					.select({ outreachId: jobOutreachMessages.outreachId })
+					.from(jobOutreachMessages)
+					.where(
+						or(
+							eq(sql`lower(${jobOutreachMessages.messageId})`, refId),
+							eq(sql`lower(${jobOutreachMessages.messageId})`, cleanRef),
+						),
+					)
+					.limit(1);
+
+				if (matchedOutreachMsg) {
+					targetInquiryId = matchedOutreachMsg.outreachId;
+					targetInquiryType = "job_outreach" as unknown as typeof targetInquiryType;
+					break;
+				}
+
+				const [matchedInquiryMsg] = await db
+					.select({ inquiryId: inquiryMessages.inquiryId, inquiryType: inquiryMessages.inquiryType })
+					.from(inquiryMessages)
+					.where(
+						or(
+							eq(sql`lower(${inquiryMessages.messageId})`, refId),
+							eq(sql`lower(${inquiryMessages.messageId})`, cleanRef),
+						),
+					)
+					.limit(1);
+
+				if (matchedInquiryMsg) {
+					targetInquiryId = matchedInquiryMsg.inquiryId;
+					targetInquiryType = matchedInquiryMsg.inquiryType;
+					break;
+				}
+			}
+		}
+
+		// 7. Match by Subject + Sender Email ONLY if the subject is explicitly a reply (starts with Re:) and matches previous entity subject
+		if (!targetInquiryId && senderEmail && isReplyOrFwd) {
+			const normIncomingSubject = normalizeSubject(subject);
+
 			const [latestOutreachRows, latestContactRows, latestServiceRows, latestHireRows] = await Promise.all([
 				db
 					.select()
 					.from(jobOutreaches)
 					.where(sql`lower(${jobOutreaches.contactEmail}) = ${senderEmail.toLowerCase()}`)
 					.orderBy(desc(jobOutreaches.createdAt))
-					.limit(1),
+					.limit(3),
 				db
 					.select()
 					.from(contacts)
 					.where(sql`lower(${contacts.email}) = ${senderEmail.toLowerCase()}`)
 					.orderBy(desc(contacts.createdAt))
-					.limit(1),
+					.limit(3),
 				db
 					.select()
 					.from(serviceRequests)
 					.where(sql`lower(${serviceRequests.email}) = ${senderEmail.toLowerCase()}`)
 					.orderBy(desc(serviceRequests.createdAt))
-					.limit(1),
+					.limit(3),
 				db
 					.select()
 					.from(hireRequests)
 					.where(sql`lower(${hireRequests.email}) = ${senderEmail.toLowerCase()}`)
 					.orderBy(desc(hireRequests.createdAt))
-					.limit(1),
+					.limit(3),
 			]);
 
-			const allMatches = [
-				latestOutreachRows[0]
-					? {
-							id: latestOutreachRows[0].id,
-							type: "job_outreach" as const,
-							subject: latestOutreachRows[0].subject,
-							contactName: latestOutreachRows[0].contactName,
-							createdAt: new Date(latestOutreachRows[0].sentAt || latestOutreachRows[0].createdAt).getTime(),
-						}
-					: null,
-				latestContactRows[0]
-					? {
-							id: latestContactRows[0].id,
-							type: "contact" as const,
-							subject: latestContactRows[0].subject,
-							contactName: latestContactRows[0].name,
-							createdAt: new Date(latestContactRows[0].createdAt).getTime(),
-						}
-					: null,
-				latestServiceRows[0]
-					? {
-							id: latestServiceRows[0].id,
-							type: "service_request" as const,
-							subject: latestServiceRows[0].serviceType,
-							contactName: latestServiceRows[0].name,
-							createdAt: new Date(latestServiceRows[0].createdAt).getTime(),
-						}
-					: null,
-				latestHireRows[0]
-					? {
-							id: latestHireRows[0].id,
-							type: "hire_request" as const,
-							subject: `${latestHireRows[0].roleTitle} @ ${latestHireRows[0].company}`,
-							contactName: latestHireRows[0].name,
-							createdAt: new Date(latestHireRows[0].createdAt).getTime(),
-						}
-					: null,
-			].filter(Boolean) as Array<{
-				id: string;
-				type: "job_outreach" | "contact" | "service_request" | "hire_request";
-				subject: string;
-				contactName: string;
-				createdAt: number;
-			}>;
-
-			if (allMatches.length > 0) {
-				allMatches.sort((a, b) => b.createdAt - a.createdAt);
-				const bestMatch = allMatches[0];
-
-				if (bestMatch.type === "job_outreach") {
-					// Deduplication check
-					const fifteenSecondsAgo = new Date(Date.now() - 15000);
-					const [recentDuplicate] = await db
-						.select()
-						.from(jobOutreachMessages)
-						.where(
-							and(
-								eq(jobOutreachMessages.outreachId, bestMatch.id),
-								eq(jobOutreachMessages.senderEmail, senderEmail),
-								eq(jobOutreachMessages.message, textContent),
-								gte(jobOutreachMessages.createdAt, fifteenSecondsAgo),
-							),
-						)
-						.limit(1);
-
-					if (recentDuplicate) {
-						console.log(
-							`[Resend Inbound] Ignored duplicate job outreach reply within 15s for ${bestMatch.id}`
-						);
-						return NextResponse.json({ success: true, duplicate: true });
-					}
-
-					await db.insert(jobOutreachMessages).values({
-						outreachId: bestMatch.id,
-						senderType: "client",
-						senderName: senderName || bestMatch.contactName || "Recruiter",
-						senderEmail,
-						message: textContent,
-					});
-
-					await db
-						.update(jobOutreaches)
-						.set({
-							status: "replied",
-							lastRepliedAt: new Date(),
-							updatedAt: new Date(),
-						})
-						.where(eq(jobOutreaches.id, bestMatch.id));
-
-					await sendInboundAlertToAdmin({
-						inquiryId: bestMatch.id,
-						inquiryType: "job_outreach",
-						clientName: senderName || bestMatch.contactName || "Recruiter",
-						clientEmail: senderEmail,
-						subject: bestMatch.subject,
-						message: textContent,
-					});
-
-					console.log(
-						`[Resend Inbound] Fallback matched email to Job Outreach ${bestMatch.id} from ${senderEmail}`
+			// Match by normalized subject
+			const matchingOutreach = latestOutreachRows.find(
+				r => normalizeSubject(r.subject) === normIncomingSubject,
+			);
+			if (matchingOutreach) {
+				targetInquiryId = matchingOutreach.id;
+				targetInquiryType = "job_outreach" as unknown as typeof targetInquiryType;
+				targetSubject = matchingOutreach.subject;
+			} else {
+				const matchingContact = latestContactRows.find(
+					r => normalizeSubject(r.subject) === normIncomingSubject,
+				);
+				if (matchingContact) {
+					targetInquiryId = matchingContact.id;
+					targetInquiryType = "contact";
+					targetSubject = matchingContact.subject;
+				} else {
+					const matchingService = latestServiceRows.find(
+						r => normalizeSubject(r.serviceType) === normIncomingSubject,
 					);
-
-					return NextResponse.json({
-						success: true,
-						outreachId: bestMatch.id,
-						matched: true,
-						type: "job_outreach",
-					});
+					if (matchingService) {
+						targetInquiryId = matchingService.id;
+						targetInquiryType = "service_request";
+						targetSubject = matchingService.serviceType;
+					} else {
+						const matchingHire = latestHireRows.find(
+							r => normalizeSubject(`${r.roleTitle} @ ${r.company}`) === normIncomingSubject,
+						);
+						if (matchingHire) {
+							targetInquiryId = matchingHire.id;
+							targetInquiryType = "hire_request";
+							targetSubject = `${matchingHire.roleTitle} @ ${matchingHire.company}`;
+						}
+					}
 				}
-
-				targetInquiryId = bestMatch.id;
-				targetInquiryType = bestMatch.type;
-				targetSubject = bestMatch.subject;
 			}
 		}
 
-		// 7. If still not matched, create a new contact inquiry so the email is NEVER lost and visible in CMS
+		// Handle matched Job Outreach if resolved via threading headers or subject
+		if (targetInquiryId && (targetInquiryType as string) === "job_outreach") {
+			const [outreachRow] = await db
+				.select()
+				.from(jobOutreaches)
+				.where(eq(jobOutreaches.id, targetInquiryId))
+				.limit(1);
+
+			if (outreachRow) {
+				const fifteenSecondsAgo = new Date(Date.now() - 15000);
+				const [recentDuplicate] = await db
+					.select()
+					.from(jobOutreachMessages)
+					.where(
+						and(
+							eq(jobOutreachMessages.outreachId, outreachRow.id),
+							eq(jobOutreachMessages.senderEmail, senderEmail),
+							eq(jobOutreachMessages.message, textContent),
+							gte(jobOutreachMessages.createdAt, fifteenSecondsAgo),
+						),
+					)
+					.limit(1);
+
+				if (recentDuplicate) {
+					return NextResponse.json({ success: true, duplicate: true });
+				}
+
+				await db.insert(jobOutreachMessages).values({
+					outreachId: outreachRow.id,
+					senderType: "client",
+					senderName: senderName || outreachRow.contactName || "Recruiter",
+					senderEmail,
+					message: textContent,
+					messageId: inboundMessageId || null,
+				});
+
+				await db
+					.update(jobOutreaches)
+					.set({
+						status: "replied",
+						lastRepliedAt: new Date(),
+						updatedAt: new Date(),
+					})
+					.where(eq(jobOutreaches.id, outreachRow.id));
+
+				await sendInboundAlertToAdmin({
+					inquiryId: outreachRow.id,
+					inquiryType: "job_outreach",
+					clientName: senderName || outreachRow.contactName || "Recruiter",
+					clientEmail: senderEmail,
+					subject: outreachRow.subject,
+					message: textContent,
+					isNewConversation: false,
+				});
+
+				return NextResponse.json({
+					success: true,
+					outreachId: outreachRow.id,
+					matched: true,
+					type: "job_outreach",
+				});
+			}
+		}
+
+		// 8. If still not matched, this is a BRAND NEW DIRECT EMAIL -> Create a new contact inquiry so it is visible in CMS Contacts!
+		let isNewInquiry = false;
 		if (!targetInquiryId) {
-			const cleanSubject = subject.replace(/^(Re:\s*)+/i, "").trim() || "Inbound Email";
+			isNewInquiry = true;
+			const cleanSubject = subject.replace(/^(?:re|fwd|fw):\s*/gi, "").trim() || "Inbound Email";
 			const [newContact] = await db
 				.insert(contacts)
 				.values({
@@ -554,6 +613,7 @@ export async function POST(req: NextRequest) {
 					subject: cleanSubject,
 					message: textContent,
 					status: "new",
+					messageId: inboundMessageId || null,
 				})
 				.returning({ id: contacts.id });
 
@@ -562,7 +622,7 @@ export async function POST(req: NextRequest) {
 			targetSubject = cleanSubject;
 
 			console.log(
-				`[Resend Inbound] No existing inquiry found. Created new contact ${targetInquiryId} for ${senderEmail}`
+				`[Resend Inbound] Direct email received. Created new contact ${targetInquiryId} (${cleanSubject}) for ${senderEmail}`
 			);
 		}
 
@@ -596,6 +656,7 @@ export async function POST(req: NextRequest) {
 			senderName: senderName || "Client",
 			senderEmail,
 			message: textContent,
+			messageId: inboundMessageId || null,
 		});
 
 		// 9. Update inquiry status to "new" to highlight it in CMS
@@ -624,6 +685,7 @@ export async function POST(req: NextRequest) {
 			clientEmail: senderEmail,
 			subject: targetSubject,
 			message: textContent,
+			isNewConversation: isNewInquiry,
 		});
 
 		console.log(

--- a/src/app/cv/cv-view.tsx
+++ b/src/app/cv/cv-view.tsx
@@ -121,7 +121,7 @@ export function CVView({ user, experiences, education, skills, settings }: CVVie
 	const { isDark, setTheme } = useTheme();
 
 	const name = user?.displayName || settings.siteName || "Wisman Nur";
-	const email = user?.email || settings.publicEmail || "wismannur.pro@gmail.com";
+	const email = user?.email || settings.publicEmail || "hi@wismannur.pro";
 	const location = user?.location || settings.location || "Indonesia";
 	const website = user?.website || "https://wismannur.pro";
 	const github = user?.social?.github || settings.social?.github;

--- a/src/components/detail/author-bio.tsx
+++ b/src/components/detail/author-bio.tsx
@@ -40,7 +40,7 @@ const AuthorBio = () => {
 			url: authorData?.social.github || "https://github.com/wismannur",
 			icon: <Github size={15} />,
 		},
-		{ name: "Email", url: `mailto:${authorData?.email || "wismannur.pro@gmail.com"}`, icon: <Mail size={15} /> },
+		{ name: "Email", url: `mailto:${authorData?.email || "hi@wismannur.pro"}`, icon: <Mail size={15} /> },
 	];
 
 	return (

--- a/src/db/migrations/0009_gifted_mercury.sql
+++ b/src/db/migrations/0009_gifted_mercury.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "contacts" ADD COLUMN "message_id" text;--> statement-breakpoint
+ALTER TABLE "hire_requests" ADD COLUMN "message_id" text;--> statement-breakpoint
+ALTER TABLE "inquiry_messages" ADD COLUMN "message_id" text;--> statement-breakpoint
+ALTER TABLE "job_outreach_messages" ADD COLUMN "message_id" text;--> statement-breakpoint
+ALTER TABLE "job_outreaches" ADD COLUMN "initial_message_id" text;--> statement-breakpoint
+ALTER TABLE "service_requests" ADD COLUMN "message_id" text;

--- a/src/db/migrations/meta/0009_snapshot.json
+++ b/src/db/migrations/meta/0009_snapshot.json
@@ -1,0 +1,2603 @@
+{
+  "id": "c418cd30-5d18-4550-9673-b93f17539a05",
+  "prevId": "9da53508-897d-41f9-9ba4-0bbc22780bc9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.availability_slots": {
+      "name": "availability_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "availability_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Available'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blogs": {
+      "name": "blogs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published_date": {
+          "name": "published_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "likes": {
+          "name": "likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reading_time": {
+          "name": "reading_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blogs_slug_unique": {
+          "name": "blogs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "contact_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.faqs": {
+      "name": "faqs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hire_requests": {
+      "name": "hire_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_title": {
+          "name": "role_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employment_type": {
+          "name": "employment_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full_time'"
+        },
+        "workplace_type": {
+          "name": "workplace_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'remote'"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary_range": {
+          "name": "salary_range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "hire_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inquiry_messages": {
+      "name": "inquiry_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inquiry_id": {
+          "name": "inquiry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inquiry_type": {
+          "name": "inquiry_type",
+          "type": "inquiry_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_type": {
+          "name": "sender_type",
+          "type": "message_sender_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_email": {
+          "name": "sender_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_applications": {
+      "name": "job_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_website": {
+          "name": "company_website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_url": {
+          "name": "job_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "job_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'linkedin'"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workplace_type": {
+          "name": "workplace_type",
+          "type": "workplace_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'remote'"
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "job_employment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full_time'"
+        },
+        "salary_min": {
+          "name": "salary_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary_max": {
+          "name": "salary_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary_currency": {
+          "name": "salary_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'IDR'"
+        },
+        "salary_period": {
+          "name": "salary_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "job_description_raw": {
+          "name": "job_description_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "status": {
+          "name": "status",
+          "type": "job_application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'wishlist'"
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ats_score": {
+          "name": "ats_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ats_analysis": {
+          "name": "ats_analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tailored_summary": {
+          "name": "tailored_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tailored_bullet_points": {
+          "name": "tailored_bullet_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_letter": {
+          "name": "cover_letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_date": {
+          "name": "follow_up_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_interviews": {
+      "name": "job_interviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_type": {
+          "name": "stage_type",
+          "type": "interview_stage_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hr_screening'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interviewers": {
+          "name": "interviewers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_link": {
+          "name": "meeting_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_invitation": {
+          "name": "raw_invitation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_summary": {
+          "name": "ai_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_predicted_questions": {
+          "name": "ai_predicted_questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "interview_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "job_interviews_application_id_job_applications_id_fk": {
+          "name": "job_interviews_application_id_job_applications_id_fk",
+          "tableFrom": "job_interviews",
+          "tableTo": "job_applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_outreach_messages": {
+      "name": "job_outreach_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "outreach_id": {
+          "name": "outreach_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_type": {
+          "name": "sender_type",
+          "type": "message_sender_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_email": {
+          "name": "sender_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "job_outreach_messages_outreach_id_job_outreaches_id_fk": {
+          "name": "job_outreach_messages_outreach_id_job_outreaches_id_fk",
+          "tableFrom": "job_outreach_messages",
+          "tableTo": "job_outreaches",
+          "columnsFrom": [
+            "outreach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_outreaches": {
+      "name": "job_outreaches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_application_id": {
+          "name": "job_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_website": {
+          "name": "company_website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_role": {
+          "name": "contact_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_linkedin": {
+          "name": "contact_linkedin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outreach_type": {
+          "name": "outreach_type",
+          "type": "outreach_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cold_pitch'"
+        },
+        "status": {
+          "name": "status",
+          "type": "outreach_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initial_message_id": {
+          "name": "initial_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_date": {
+          "name": "follow_up_due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_replied_at": {
+          "name": "last_replied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "job_outreaches_job_application_id_job_applications_id_fk": {
+          "name": "job_outreaches_job_application_id_job_applications_id_fk",
+          "tableFrom": "job_outreaches",
+          "tableTo": "job_applications",
+          "columnsFrom": [
+            "job_application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.offers": {
+      "name": "offers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "for_who": {
+          "name": "for_who",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "extras": {
+          "name": "extras",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "is_popular": {
+          "name": "is_popular",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "offers_slug_unique": {
+          "name": "offers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_copy": {
+      "name": "page_copy",
+      "schema": "",
+      "columns": {
+        "page": {
+          "name": "page",
+          "type": "page_key",
+          "typeSchema": "public",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pricing_tiers": {
+      "name": "pricing_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_label": {
+          "name": "price_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "is_popular": {
+          "name": "is_popular",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cta_label": {
+          "name": "cta_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Get Started'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pricing_tiers_slug_unique": {
+          "name": "pricing_tiers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.process_steps": {
+      "name": "process_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "process_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published_date": {
+          "name": "published_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "technologies": {
+          "name": "technologies",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "demo_url": {
+          "name": "demo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "likes": {
+          "name": "likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reading_time": {
+          "name": "reading_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resume_entries": {
+      "name": "resume_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "resume_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization": {
+          "name": "organization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_current": {
+          "name": "is_current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_requests": {
+      "name": "service_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_type": {
+          "name": "service_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "budget": {
+          "name": "budget",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timeframe": {
+          "name": "timeframe",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_details": {
+          "name": "project_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "service_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "long_description": {
+          "name": "long_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_label": {
+          "name": "price_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "features": {
+          "name": "features",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "show_on_home": {
+          "name": "show_on_home",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_on_hire_me": {
+          "name": "show_on_hire_me",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "services_slug_unique": {
+          "name": "services_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.site_pages": {
+      "name": "site_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "site_pages_slug_unique": {
+          "name": "site_pages_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.site_settings": {
+      "name": "site_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'site'"
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_default": {
+          "name": "title_default",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_template": {
+          "name": "title_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "twitter_handle": {
+          "name": "twitter_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "theme_color": {
+          "name": "theme_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#4F46E5'"
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "og_tagline": {
+          "name": "og_tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "public_email": {
+          "name": "public_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "timezone_label": {
+          "name": "timezone_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "social": {
+          "name": "social",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footer_bio": {
+          "name": "footer_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "footer_tagline": {
+          "name": "footer_tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "copyright_name": {
+          "name": "copyright_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "repo_link_label": {
+          "name": "repo_link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "footer_project_links": {
+          "name": "footer_project_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "request_timeframes": {
+          "name": "request_timeframes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "request_budget_ranges": {
+          "name": "request_budget_ranges",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "enable_blog": {
+          "name": "enable_blog",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.testimonials": {
+      "name": "testimonials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_role": {
+          "name": "author_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote": {
+          "name": "quote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "theme": {
+          "name": "theme",
+          "type": "theme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "color_scheme": {
+          "name": "color_scheme",
+          "type": "color_scheme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'blue'"
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "marketing_emails": {
+          "name": "marketing_emails",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "new_comment_notifications": {
+          "name": "new_comment_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "mention_notifications": {
+          "name": "mention_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asia/Jakarta'"
+        },
+        "date_format": {
+          "name": "date_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DD/MM/YYYY'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_uid_fk": {
+          "name": "user_settings_user_id_users_uid_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "uid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "social": {
+          "name": "social",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.availability_status": {
+      "name": "availability_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "limited",
+        "booked"
+      ]
+    },
+    "public.color_scheme": {
+      "name": "color_scheme",
+      "schema": "public",
+      "values": [
+        "blue",
+        "purple",
+        "green",
+        "orange",
+        "red"
+      ]
+    },
+    "public.contact_status": {
+      "name": "contact_status",
+      "schema": "public",
+      "values": [
+        "new",
+        "read",
+        "replied",
+        "archived"
+      ]
+    },
+    "public.hire_request_status": {
+      "name": "hire_request_status",
+      "schema": "public",
+      "values": [
+        "new",
+        "reviewed",
+        "interviewing",
+        "offered",
+        "rejected",
+        "archived"
+      ]
+    },
+    "public.inquiry_type": {
+      "name": "inquiry_type",
+      "schema": "public",
+      "values": [
+        "contact",
+        "service_request",
+        "hire_request"
+      ]
+    },
+    "public.interview_stage_type": {
+      "name": "interview_stage_type",
+      "schema": "public",
+      "values": [
+        "hr_screening",
+        "technical_interview",
+        "live_coding",
+        "take_home_test",
+        "user_interview",
+        "system_design",
+        "final_leadership",
+        "offering_discussion",
+        "other"
+      ]
+    },
+    "public.interview_status": {
+      "name": "interview_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "completed",
+        "passed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.job_application_status": {
+      "name": "job_application_status",
+      "schema": "public",
+      "values": [
+        "wishlist",
+        "applied",
+        "screening",
+        "interview_hr",
+        "interview_tech",
+        "interview_user",
+        "offering",
+        "accepted",
+        "rejected",
+        "withdrawn",
+        "ghosted"
+      ]
+    },
+    "public.job_employment_type": {
+      "name": "job_employment_type",
+      "schema": "public",
+      "values": [
+        "full_time",
+        "contract",
+        "part_time",
+        "freelance",
+        "internship"
+      ]
+    },
+    "public.job_platform": {
+      "name": "job_platform",
+      "schema": "public",
+      "values": [
+        "linkedin",
+        "jobstreet",
+        "glints",
+        "techinasia",
+        "indeed",
+        "company_website",
+        "referral",
+        "other"
+      ]
+    },
+    "public.message_sender_type": {
+      "name": "message_sender_type",
+      "schema": "public",
+      "values": [
+        "admin",
+        "client"
+      ]
+    },
+    "public.outreach_status": {
+      "name": "outreach_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "sent",
+        "follow_up_due",
+        "replied",
+        "converted",
+        "closed"
+      ]
+    },
+    "public.outreach_type": {
+      "name": "outreach_type",
+      "schema": "public",
+      "values": [
+        "direct_apply",
+        "cold_pitch",
+        "follow_up"
+      ]
+    },
+    "public.page_key": {
+      "name": "page_key",
+      "schema": "public",
+      "values": [
+        "home",
+        "about",
+        "services",
+        "hire-me",
+        "offers",
+        "blog",
+        "projects",
+        "contact",
+        "not-found",
+        "default"
+      ]
+    },
+    "public.process_scope": {
+      "name": "process_scope",
+      "schema": "public",
+      "values": [
+        "services",
+        "hire-me"
+      ]
+    },
+    "public.resume_kind": {
+      "name": "resume_kind",
+      "schema": "public",
+      "values": [
+        "experience",
+        "education"
+      ]
+    },
+    "public.service_request_status": {
+      "name": "service_request_status",
+      "schema": "public",
+      "values": [
+        "new",
+        "in-progress",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.theme": {
+      "name": "theme",
+      "schema": "public",
+      "values": [
+        "light",
+        "dark",
+        "system"
+      ]
+    },
+    "public.workplace_type": {
+      "name": "workplace_type",
+      "schema": "public",
+      "values": [
+        "remote",
+        "hybrid",
+        "onsite"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1788110017753,
       "tag": "0008_curious_nebula",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1788157269295,
+      "tag": "0009_gifted_mercury",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -213,6 +213,7 @@ export const contacts = pgTable("contacts", {
 	subject: text("subject").notNull(),
 	message: text("message").notNull(),
 	status: contactStatus("status").notNull().default("new"),
+	messageId: text("message_id"),
 	createdAt: timestamp("created_at", { withTimezone: true })
 		.notNull()
 		.defaultNow(),
@@ -230,6 +231,7 @@ export const serviceRequests = pgTable("service_requests", {
 	timeframe: text("timeframe").notNull(),
 	projectDetails: text("project_details").notNull(),
 	status: serviceRequestStatus("status").notNull().default("new"),
+	messageId: text("message_id"),
 	createdAt: timestamp("created_at", { withTimezone: true })
 		.notNull()
 		.defaultNow(),
@@ -249,6 +251,7 @@ export const hireRequests = pgTable("hire_requests", {
 	salaryRange: text("salary_range"),
 	message: text("message").notNull(),
 	status: hireRequestStatus("status").notNull().default("new"),
+	messageId: text("message_id"),
 	createdAt: timestamp("created_at", { withTimezone: true })
 		.notNull()
 		.defaultNow(),
@@ -696,6 +699,7 @@ export const jobOutreaches = pgTable("job_outreaches", {
 	body: text("body").notNull(),
 	notes: text("notes"),
 	attachments: jsonb("attachments"),
+	initialMessageId: text("initial_message_id"),
 	sentAt: timestamp("sent_at", { withTimezone: true }),
 	followUpDueDate: timestamp("follow_up_due_date", { withTimezone: true }),
 	lastRepliedAt: timestamp("last_replied_at", { withTimezone: true }),
@@ -719,6 +723,7 @@ export const jobOutreachMessages = pgTable("job_outreach_messages", {
 	senderName: text("sender_name").notNull(),
 	senderEmail: text("sender_email").notNull(),
 	message: text("message").notNull(),
+	messageId: text("message_id"),
 	createdAt: timestamp("created_at", { withTimezone: true })
 		.notNull()
 		.defaultNow(),
@@ -734,6 +739,7 @@ export const inquiryMessages = pgTable("inquiry_messages", {
 	senderName: text("sender_name").notNull(),
 	senderEmail: text("sender_email").notNull(),
 	message: text("message").notNull(),
+	messageId: text("message_id"),
 	createdAt: timestamp("created_at", { withTimezone: true })
 		.notNull()
 		.defaultNow(),

--- a/src/services/contacts/actions.ts
+++ b/src/services/contacts/actions.ts
@@ -76,7 +76,13 @@ export async function submit(formData: ContactForm, recaptchaToken?: string): Pr
 		.insert(contacts)
 		.values({ ...clean, status: "new" })
 		.returning({ id: contacts.id });
-	await sendContactEmails({ ...clean, id });
+	const { clientEmailId } = await sendContactEmails({ ...clean, id });
+	if (clientEmailId) {
+		await getDb()
+			.update(contacts)
+			.set({ messageId: clientEmailId })
+			.where(eq(contacts.id, id));
+	}
 
 	return id;
 }

--- a/src/services/core/resend.ts
+++ b/src/services/core/resend.ts
@@ -61,13 +61,15 @@ interface HireRequestEmailPayload {
 	message: string;
 }
 
-interface AdminReplyPayload {
+export interface AdminReplyPayload {
 	inquiryId: string;
 	toEmail: string;
 	toName: string;
 	subject: string;
 	message: string;
 	originalMessageSnippet?: string;
+	inReplyToId?: string | null;
+	referencesIds?: (string | null | undefined)[];
 }
 
 interface InboundAlertPayload {
@@ -77,6 +79,7 @@ interface InboundAlertPayload {
 	clientEmail: string;
 	subject: string;
 	message: string;
+	isNewConversation?: boolean;
 }
 
 export interface JobOutreachSendPayload {
@@ -89,26 +92,77 @@ export interface JobOutreachSendPayload {
 	jobTitle?: string;
 	isFollowUp?: boolean;
 	attachments?: Array<{ name: string; url: string }>;
+	inReplyToId?: string | null;
+	referencesIds?: (string | null | undefined)[];
 }
 
+/**
+ * Formats a message ID for RFC 5322 In-Reply-To and References headers.
+ * Standard RFC headers require angle brackets `<...>`, e.g. `<id@domain.com>` or `<resend-uuid@resend.dev>`.
+ */
+export function formatMessageIdHeader(id: string | null | undefined): string | null {
+	if (!id) return null;
+	const trimmed = id.trim();
+	if (!trimmed) return null;
+	if (trimmed.startsWith("<") && trimmed.endsWith(">")) {
+		return trimmed;
+	}
+	if (trimmed.includes("@")) {
+		return `<${trimmed}>`;
+	}
+	// For Resend IDs (which are UUIDs/alphanumerics), Resend sets the Message-ID as <id@resend.dev>
+	return `<${trimmed}@resend.dev>`;
+}
 
+/**
+ * Constructs email headers containing X-Entity-Ref-ID, In-Reply-To, and References for proper email client threading.
+ */
+export function buildThreadingHeaders(params: {
+	entityRefId?: string;
+	inReplyToId?: string | null;
+	referencesIds?: (string | null | undefined)[];
+}): Record<string, string> {
+	const headers: Record<string, string> = {};
+
+	if (params.entityRefId) {
+		headers["X-Entity-Ref-ID"] = params.entityRefId;
+	}
+
+	const formattedInReplyTo = formatMessageIdHeader(params.inReplyToId);
+	if (formattedInReplyTo) {
+		headers["In-Reply-To"] = formattedInReplyTo;
+	}
+
+	const validRefs = (params.referencesIds || [])
+		.map(formatMessageIdHeader)
+		.filter((id): id is string => Boolean(id));
+
+	const uniqueRefs = Array.from(new Set(validRefs));
+	if (uniqueRefs.length > 0) {
+		headers["References"] = uniqueRefs.join(" ");
+	}
+
+	return headers;
+}
 
 /**
  * Sends both Admin notification and Client auto-reply for contact inquiries.
  * Fail-safe: Any Resend error is caught and logged, never bubbling up to crash the form submission.
  */
-export async function sendContactEmails(payload: ContactEmailPayload): Promise<void> {
+export async function sendContactEmails(
+	payload: ContactEmailPayload,
+): Promise<{ clientEmailId?: string; adminEmailId?: string }> {
 	const resend = getResendClient();
 	if (!resend) {
 		console.warn("Resend is not configured: RESEND_API_KEY is missing. Skipping email delivery.");
-		return;
+		return {};
 	}
 
 	try {
 		const sentAt = new Date().toLocaleString("id-ID", { timeZone: "Asia/Jakarta" });
 		const dynamicReplyTo = payload.id ? `${payload.id}@wismannur.pro` : "hi@wismannur.pro";
 
-		await Promise.allSettled([
+		const [adminRes, clientRes] = await Promise.allSettled([
 			// 1. Notification to Admin
 			resend.emails.send({
 				from: SENDER_NOTIFICATIONS,
@@ -140,8 +194,16 @@ export async function sendContactEmails(payload: ContactEmailPayload): Promise<v
 				}),
 			}),
 		]);
+
+		const adminEmailId =
+			adminRes.status === "fulfilled" && adminRes.value.data?.id ? adminRes.value.data.id : undefined;
+		const clientEmailId =
+			clientRes.status === "fulfilled" && clientRes.value.data?.id ? clientRes.value.data.id : undefined;
+
+		return { adminEmailId, clientEmailId };
 	} catch (error) {
 		console.error("Failed to send contact emails via Resend:", error);
+		return {};
 	}
 }
 
@@ -149,18 +211,20 @@ export async function sendContactEmails(payload: ContactEmailPayload): Promise<v
  * Sends both Admin notification and Client auto-reply for Hire-Me service requests.
  * Fail-safe: Any Resend error is caught and logged, never bubbling up to crash the form submission.
  */
-export async function sendServiceRequestEmails(payload: ServiceRequestEmailPayload): Promise<void> {
+export async function sendServiceRequestEmails(
+	payload: ServiceRequestEmailPayload,
+): Promise<{ clientEmailId?: string; adminEmailId?: string }> {
 	const resend = getResendClient();
 	if (!resend) {
 		console.warn("Resend is not configured: RESEND_API_KEY is missing. Skipping email delivery.");
-		return;
+		return {};
 	}
 
 	try {
 		const sentAt = new Date().toLocaleString("id-ID", { timeZone: "Asia/Jakarta" });
 		const dynamicReplyTo = payload.id ? `${payload.id}@wismannur.pro` : "hi@wismannur.pro";
 
-		await Promise.allSettled([
+		const [adminRes, clientRes] = await Promise.allSettled([
 			// 1. Notification to Admin
 			resend.emails.send({
 				from: SENDER_NOTIFICATIONS,
@@ -197,8 +261,16 @@ export async function sendServiceRequestEmails(payload: ServiceRequestEmailPaylo
 				}),
 			}),
 		]);
+
+		const adminEmailId =
+			adminRes.status === "fulfilled" && adminRes.value.data?.id ? adminRes.value.data.id : undefined;
+		const clientEmailId =
+			clientRes.status === "fulfilled" && clientRes.value.data?.id ? clientRes.value.data.id : undefined;
+
+		return { adminEmailId, clientEmailId };
 	} catch (error) {
 		console.error("Failed to send service request emails via Resend:", error);
+		return {};
 	}
 }
 
@@ -206,18 +278,20 @@ export async function sendServiceRequestEmails(payload: ServiceRequestEmailPaylo
  * Sends both Admin notification and Client auto-reply for Hire-Me career/job inquiries.
  * Fail-safe: Any Resend error is caught and logged, never bubbling up to crash the form submission.
  */
-export async function sendHireRequestEmails(payload: HireRequestEmailPayload): Promise<void> {
+export async function sendHireRequestEmails(
+	payload: HireRequestEmailPayload,
+): Promise<{ clientEmailId?: string; adminEmailId?: string }> {
 	const resend = getResendClient();
 	if (!resend) {
 		console.warn("Resend is not configured: RESEND_API_KEY is missing. Skipping email delivery.");
-		return;
+		return {};
 	}
 
 	try {
 		const sentAt = new Date().toLocaleString("id-ID", { timeZone: "Asia/Jakarta" });
 		const dynamicReplyTo = payload.id ? `${payload.id}@wismannur.pro` : "hi@wismannur.pro";
 
-		await Promise.allSettled([
+		const [adminRes, clientRes] = await Promise.allSettled([
 			// 1. Notification to Admin
 			resend.emails.send({
 				from: SENDER_NOTIFICATIONS,
@@ -257,19 +331,27 @@ export async function sendHireRequestEmails(payload: HireRequestEmailPayload): P
 				}),
 			}),
 		]);
+
+		const adminEmailId =
+			adminRes.status === "fulfilled" && adminRes.value.data?.id ? adminRes.value.data.id : undefined;
+		const clientEmailId =
+			clientRes.status === "fulfilled" && clientRes.value.data?.id ? clientRes.value.data.id : undefined;
+
+		return { adminEmailId, clientEmailId };
 	} catch (error) {
 		console.error("Failed to send hire request emails via Resend:", error);
+		return {};
 	}
 }
 
 /**
  * Sends an email response from the Admin directly to the Client.
  */
-export async function sendAdminReplyToClient(payload: AdminReplyPayload): Promise<void> {
+export async function sendAdminReplyToClient(payload: AdminReplyPayload): Promise<{ id?: string }> {
 	const resend = getResendClient();
 	if (!resend) {
 		console.warn("Resend is not configured: RESEND_API_KEY is missing. Skipping reply email.");
-		return;
+		return {};
 	}
 
 	try {
@@ -278,14 +360,18 @@ export async function sendAdminReplyToClient(payload: AdminReplyPayload): Promis
 			formattedSubject = `Re: ${formattedSubject}`;
 		}
 
-		await resend.emails.send({
+		const headers = buildThreadingHeaders({
+			entityRefId: payload.inquiryId,
+			inReplyToId: payload.inReplyToId,
+			referencesIds: payload.referencesIds,
+		});
+
+		const { data, error } = await resend.emails.send({
 			from: SENDER_HI,
 			to: payload.toEmail,
 			replyTo: payload.inquiryId ? `${payload.inquiryId}@wismannur.pro` : "hi@wismannur.pro",
 			subject: formattedSubject,
-			headers: {
-				"X-Entity-Ref-ID": payload.inquiryId,
-			},
+			headers,
 			react: AdminReplyToClientEmail({
 				clientName: payload.toName,
 				replyMessage: payload.message,
@@ -294,6 +380,13 @@ export async function sendAdminReplyToClient(payload: AdminReplyPayload): Promis
 				inquiryId: payload.inquiryId,
 			}),
 		});
+
+		if (error) {
+			console.error("[Resend] Error sending admin reply to client:", error);
+			throw error;
+		}
+
+		return { id: data?.id };
 	} catch (error) {
 		console.error("Failed to send admin reply email via Resend:", error);
 		throw error;
@@ -311,10 +404,14 @@ export async function sendInboundAlertToAdmin(payload: InboundAlertPayload): Pro
 	}
 
 	try {
+		const alertSubject = payload.isNewConversation
+			? `[New Direct Email] ${payload.clientName}: ${payload.subject}`
+			: `[Inbound Reply] ${payload.clientName} membalas: ${payload.subject}`;
+
 		await resend.emails.send({
 			from: SENDER_NOTIFICATIONS,
 			to: ADMIN_EMAIL,
-			subject: `[Inbound Reply] ${payload.clientName} membalas di CMS: ${payload.subject}`,
+			subject: alertSubject,
 			react: AdminInboundAlertEmail({
 				inquiryId: payload.inquiryId,
 				inquiryType: payload.inquiryType,
@@ -332,11 +429,11 @@ export async function sendInboundAlertToAdmin(payload: InboundAlertPayload): Pro
 /**
  * Sends an outbound job application / cold outreach / follow-up email to a recruiter or company contact.
  */
-export async function sendJobOutreachEmail(payload: JobOutreachSendPayload): Promise<void> {
+export async function sendJobOutreachEmail(payload: JobOutreachSendPayload): Promise<{ id?: string }> {
 	const resend = getResendClient();
 	if (!resend) {
 		console.warn("Resend is not configured: RESEND_API_KEY is missing. Skipping job outreach email.");
-		return;
+		return {};
 	}
 
 	try {
@@ -353,15 +450,19 @@ export async function sendJobOutreachEmail(payload: JobOutreachSendPayload): Pro
 					}))
 				: undefined;
 
-		await resend.emails.send({
+		const headers = buildThreadingHeaders({
+			entityRefId: payload.outreachId,
+			inReplyToId: payload.inReplyToId,
+			referencesIds: payload.referencesIds,
+		});
+
+		const { data, error } = await resend.emails.send({
 			from: SENDER_HI,
 			to: payload.toEmail,
 			replyTo: payload.outreachId ? `${payload.outreachId}@wismannur.pro` : "hi@wismannur.pro",
 			subject: formattedSubject,
 			attachments: resendAttachments,
-			headers: {
-				"X-Entity-Ref-ID": payload.outreachId,
-			},
+			headers,
 			react: JobOutreachEmail({
 				contactName: payload.toName,
 				bodyMessage: payload.message,
@@ -373,6 +474,12 @@ export async function sendJobOutreachEmail(payload: JobOutreachSendPayload): Pro
 			}),
 		});
 
+		if (error) {
+			console.error("[Resend] Error sending job outreach email:", error);
+			throw error;
+		}
+
+		return { id: data?.id };
 	} catch (error) {
 		console.error("Failed to send job outreach email via Resend:", error);
 		throw error;

--- a/src/services/hire-requests/actions.ts
+++ b/src/services/hire-requests/actions.ts
@@ -103,7 +103,13 @@ export async function submit(data: NewHireRequest, recaptchaToken?: string): Pro
 		})
 		.returning({ id: hireRequests.id });
 
-	await sendHireRequestEmails({ ...clean, id });
+	const { clientEmailId } = await sendHireRequestEmails({ ...clean, id });
+	if (clientEmailId) {
+		await getDb()
+			.update(hireRequests)
+			.set({ messageId: clientEmailId })
+			.where(eq(hireRequests.id, id));
+	}
 
 	return id;
 }

--- a/src/services/inquiry-messages/actions.ts
+++ b/src/services/inquiry-messages/actions.ts
@@ -38,6 +38,7 @@ export async function getThreadMessages(inquiryId: string): Promise<InquiryMessa
 		senderName: row.senderName,
 		senderEmail: row.senderEmail,
 		message: row.message,
+		messageId: row.messageId ?? undefined,
 		createdAt: row.createdAt,
 	}));
 }
@@ -52,7 +53,61 @@ export async function sendAdminReply(data: SendAdminReplyInput): Promise<Inquiry
 
 	const db = getDb();
 
-	// 1. Insert admin reply to database
+	// 1. Fetch previous thread messages and initial entity messageId to construct threading references
+	const previousMessages = await db
+		.select()
+		.from(inquiryMessages)
+		.where(eq(inquiryMessages.inquiryId, clean.inquiryId))
+		.orderBy(asc(inquiryMessages.createdAt));
+
+	const referencesIds: string[] = [];
+
+	// Check initial messageId from parent table
+	if (clean.inquiryType === "contact") {
+		const [parent] = await db
+			.select({ messageId: contacts.messageId })
+			.from(contacts)
+			.where(eq(contacts.id, clean.inquiryId))
+			.limit(1);
+		if (parent?.messageId) referencesIds.push(parent.messageId);
+	} else if (clean.inquiryType === "service_request") {
+		const [parent] = await db
+			.select({ messageId: serviceRequests.messageId })
+			.from(serviceRequests)
+			.where(eq(serviceRequests.id, clean.inquiryId))
+			.limit(1);
+		if (parent?.messageId) referencesIds.push(parent.messageId);
+	} else if (clean.inquiryType === "hire_request") {
+		const [parent] = await db
+			.select({ messageId: hireRequests.messageId })
+			.from(hireRequests)
+			.where(eq(hireRequests.id, clean.inquiryId))
+			.limit(1);
+		if (parent?.messageId) referencesIds.push(parent.messageId);
+	}
+
+	for (const msg of previousMessages) {
+		if (msg.messageId) {
+			referencesIds.push(msg.messageId);
+		}
+	}
+
+	const inReplyToId =
+		referencesIds.length > 0 ? referencesIds[referencesIds.length - 1] : null;
+
+	// 2. Send email to client via Resend with RFC 5322 In-Reply-To and References
+	const sendRes = await sendAdminReplyToClient({
+		inquiryId: clean.inquiryId,
+		toEmail: clean.toEmail,
+		toName: clean.toName,
+		subject: clean.subject,
+		message: clean.message,
+		originalMessageSnippet: clean.originalMessageSnippet,
+		inReplyToId,
+		referencesIds,
+	});
+
+	// 3. Insert admin reply to database with messageId
 	const [inserted] = await db
 		.insert(inquiryMessages)
 		.values({
@@ -62,10 +117,11 @@ export async function sendAdminReply(data: SendAdminReplyInput): Promise<Inquiry
 			senderName: "Wisman Nur",
 			senderEmail: "hi@wismannur.pro",
 			message: clean.message,
+			messageId: sendRes.id || null,
 		})
 		.returning();
 
-	// 2. Update status of the inquiry
+	// 4. Update status of the inquiry
 	if (clean.inquiryType === "contact") {
 		await db
 			.update(contacts)
@@ -83,16 +139,6 @@ export async function sendAdminReply(data: SendAdminReplyInput): Promise<Inquiry
 			.where(eq(hireRequests.id, clean.inquiryId));
 	}
 
-	// 3. Send email to client via Resend
-	await sendAdminReplyToClient({
-		inquiryId: clean.inquiryId,
-		toEmail: clean.toEmail,
-		toName: clean.toName,
-		subject: clean.subject,
-		message: clean.message,
-		originalMessageSnippet: clean.originalMessageSnippet,
-	});
-
 	return {
 		id: inserted.id,
 		inquiryId: inserted.inquiryId,
@@ -101,6 +147,7 @@ export async function sendAdminReply(data: SendAdminReplyInput): Promise<Inquiry
 		senderName: inserted.senderName,
 		senderEmail: inserted.senderEmail,
 		message: inserted.message,
+		messageId: inserted.messageId ?? undefined,
 		createdAt: inserted.createdAt,
 	};
 }

--- a/src/services/inquiry-messages/types.ts
+++ b/src/services/inquiry-messages/types.ts
@@ -9,6 +9,7 @@ export interface InquiryMessage {
 	senderName: string;
 	senderEmail: string;
 	message: string;
+	messageId?: string;
 	createdAt: Date;
 }
 

--- a/src/services/job-outreaches/actions.ts
+++ b/src/services/job-outreaches/actions.ts
@@ -70,6 +70,7 @@ const toJobOutreachMessage = (row: JobOutreachMessageRow): JobOutreachMessage =>
 	senderName: row.senderName,
 	senderEmail: row.senderEmail,
 	message: row.message,
+	messageId: row.messageId ?? undefined,
 	createdAt: row.createdAt,
 });
 
@@ -93,6 +94,7 @@ const toJobOutreach = (
 	body: row.body,
 	notes: row.notes ?? undefined,
 	attachments: (row.attachments as JobOutreachAttachment[] | null) ?? undefined,
+	initialMessageId: row.initialMessageId ?? undefined,
 	sentAt: row.sentAt ?? undefined,
 	followUpDueDate: row.followUpDueDate ?? undefined,
 	lastRepliedAt: row.lastRepliedAt ?? undefined,
@@ -260,19 +262,12 @@ export async function createJobOutreach(
 
 	// Insert initial message into thread
 	if (inserted) {
-		await db.insert(jobOutreachMessages).values({
-			outreachId: inserted.id,
-			senderType: "admin",
-			senderName: "Wisman Nur",
-			senderEmail: "hi@wismannur.pro",
-			message: inserted.body,
-			createdAt: isSending ? now : inserted.createdAt,
-		});
+		let resendId: string | undefined;
 
 		// Send email via Resend if requested
 		if (isSending) {
 			try {
-				await sendJobOutreachEmail({
+				const sendRes = await sendJobOutreachEmail({
 					outreachId: inserted.id,
 					toEmail: inserted.contactEmail,
 					toName: inserted.contactName,
@@ -282,9 +277,27 @@ export async function createJobOutreach(
 					jobTitle: inserted.jobTitle,
 					attachments: (inserted.attachments as JobOutreachAttachment[] | null) ?? undefined,
 				});
+				resendId = sendRes.id;
 			} catch (err) {
 				console.error("[Job Outreach] Failed to send email on create:", err);
 			}
+		}
+
+		await db.insert(jobOutreachMessages).values({
+			outreachId: inserted.id,
+			senderType: "admin",
+			senderName: "Wisman Nur",
+			senderEmail: "hi@wismannur.pro",
+			message: inserted.body,
+			messageId: resendId || null,
+			createdAt: isSending ? now : inserted.createdAt,
+		});
+
+		if (resendId) {
+			await db
+				.update(jobOutreaches)
+				.set({ initialMessageId: resendId })
+				.where(eq(jobOutreaches.id, inserted.id));
 		}
 	}
 
@@ -352,7 +365,7 @@ export async function sendOutreachEmail(id: string): Promise<JobOutreach> {
 	const now = new Date();
 	const followUpDate = new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000);
 
-	await sendJobOutreachEmail({
+	const sendRes = await sendJobOutreachEmail({
 		outreachId: row.id,
 		toEmail: row.contactEmail,
 		toName: row.contactName,
@@ -363,17 +376,33 @@ export async function sendOutreachEmail(id: string): Promise<JobOutreach> {
 		attachments: (row.attachments as JobOutreachAttachment[] | null) ?? undefined,
 	});
 
-
 	const [updated] = await db
 		.update(jobOutreaches)
 		.set({
 			status: "sent",
 			sentAt: now,
+			initialMessageId: sendRes.id || row.initialMessageId || null,
 			followUpDueDate: followUpDate,
 			updatedAt: now,
 		})
 		.where(eq(jobOutreaches.id, id))
 		.returning();
+
+	if (sendRes.id) {
+		const [firstMsg] = await db
+			.select()
+			.from(jobOutreachMessages)
+			.where(eq(jobOutreachMessages.outreachId, id))
+			.orderBy(asc(jobOutreachMessages.createdAt))
+			.limit(1);
+
+		if (firstMsg) {
+			await db
+				.update(jobOutreachMessages)
+				.set({ messageId: sendRes.id })
+				.where(eq(jobOutreachMessages.id, firstMsg.id));
+		}
+	}
 
 	revalidateOutreachPaths(id);
 	return toJobOutreach(updated);
@@ -398,21 +427,29 @@ export async function sendFollowUpMessage(
 
 	if (!outreach) throw new Error("Outreach not found");
 
-	// 1. Insert message into thread
-	const [newMessage] = await db
-		.insert(jobOutreachMessages)
-		.values({
-			outreachId,
-			senderType: "admin",
-			senderName: "Wisman Nur",
-			senderEmail: "hi@wismannur.pro",
-			message: followUpText.trim(),
-		})
-		.returning();
+	// 1. Fetch previous thread messages to extract inReplyToId and references
+	const previousMessages = await db
+		.select()
+		.from(jobOutreachMessages)
+		.where(eq(jobOutreachMessages.outreachId, outreachId))
+		.orderBy(asc(jobOutreachMessages.createdAt));
 
-	// 2. Send via Resend
+	const referencesIds: string[] = [];
+	if (outreach.initialMessageId) {
+		referencesIds.push(outreach.initialMessageId);
+	}
+	for (const msg of previousMessages) {
+		if (msg.messageId) {
+			referencesIds.push(msg.messageId);
+		}
+	}
+
+	const inReplyToId =
+		referencesIds.length > 0 ? referencesIds[referencesIds.length - 1] : null;
+
+	// 2. Send via Resend with In-Reply-To and References headers
 	const finalSubject = subject || outreach.subject;
-	await sendJobOutreachEmail({
+	const sendRes = await sendJobOutreachEmail({
 		outreachId,
 		toEmail: outreach.contactEmail,
 		toName: outreach.contactName,
@@ -421,9 +458,24 @@ export async function sendFollowUpMessage(
 		companyName: outreach.companyName,
 		jobTitle: outreach.jobTitle,
 		isFollowUp: true,
+		inReplyToId,
+		referencesIds,
 	});
 
-	// 3. Update outreach status & next follow-up due in 4 days
+	// 3. Insert message into thread with messageId
+	const [newMessage] = await db
+		.insert(jobOutreachMessages)
+		.values({
+			outreachId,
+			senderType: "admin",
+			senderName: "Wisman Nur",
+			senderEmail: "hi@wismannur.pro",
+			message: followUpText.trim(),
+			messageId: sendRes.id || null,
+		})
+		.returning();
+
+	// 4. Update outreach status & next follow-up due in 4 days
 	const now = new Date();
 	await db
 		.update(jobOutreaches)

--- a/src/services/job-outreaches/types.ts
+++ b/src/services/job-outreaches/types.ts
@@ -21,6 +21,7 @@ export interface JobOutreachMessage {
 	senderName: string;
 	senderEmail: string;
 	message: string;
+	messageId?: string;
 	createdAt: Date;
 }
 
@@ -40,6 +41,7 @@ export interface JobOutreach {
 	body: string;
 	notes?: string;
 	attachments?: JobOutreachAttachment[];
+	initialMessageId?: string;
 	sentAt?: Date;
 	followUpDueDate?: Date;
 	lastRepliedAt?: Date;

--- a/src/services/service-requests/actions.ts
+++ b/src/services/service-requests/actions.ts
@@ -85,7 +85,13 @@ export async function submit(data: NewServiceRequest, recaptchaToken?: string): 
 		.values({ ...clean, status: "new" })
 		.returning({ id: serviceRequests.id });
 
-	await sendServiceRequestEmails({ ...clean, id });
+	const { clientEmailId } = await sendServiceRequestEmails({ ...clean, id });
+	if (clientEmailId) {
+		await getDb()
+			.update(serviceRequests)
+			.set({ messageId: clientEmailId })
+			.where(eq(serviceRequests.id, id));
+	}
 
 	return id;
 }

--- a/src/services/site-settings/defaults.ts
+++ b/src/services/site-settings/defaults.ts
@@ -23,7 +23,7 @@ export const DEFAULT_SITE_SETTINGS: SiteSettings = {
 	ogTitle: "Frontend Software Engineer",
 	ogTagline:
 		"High-performance web applications, seamless API integrations, and intuitive user experiences.",
-	publicEmail: "wismannur.pro@gmail.com",
+	publicEmail: "hi@wismannur.pro",
 	location: "Bandung, West Java, Indonesia",
 	timezoneLabel: "Western Indonesian Time, UTC+07:00",
 	social: {


### PR DESCRIPTION
## Summary
- Implements RFC 5322 email threading (`In-Reply-To` and `References` headers) across all outreach and inquiry channels so that CMS replies continue in the recipient's existing email thread in Gmail and other email clients.
- Enhances Resend Inbound webhook matching using header references and normalized subject checks, ensuring direct inbound emails (like Google OTP verification codes or new inquiries) are routed into fresh standalone threads and appear in CMS Contacts rather than being misattributed to past job outreaches.

## Changes
- `feat(db)`: Add `message_id` and `initial_message_id` columns to database tables and apply migration `0009_gifted_mercury.sql`.
- `feat(email)`: Support RFC 5322 `In-Reply-To` and `References` headers in core Resend email dispatcher.
- `feat(inbox)`: Track message IDs and inject threading headers into follow-ups/replies across Job Outreaches, Contacts, Service Requests, and Hire Requests.
- `feat(webhook)`: Enhance inbound matching with header reference lookup and normalized subject matching, creating standalone contact records for new direct emails.

## Test plan
- Verified TypeScript compilation (\`tsc --noEmit\`) passes with 0 errors.
- Verified database migration generation and application on Neon DB.