### PR TITLE
feat(email): multi-env resend domain isolation and dynamic email configuration

### DIFF
--- a/src/app/(public)/hire-me/hire-me-view.tsx
+++ b/src/app/(public)/hire-me/hire-me-view.tsx
@@ -33,6 +33,7 @@ import { HighlightedText } from "@/components/ui/highlighted-text";
 import { toast } from "@/components/ui/use-toast";
 import { SpotlightCard } from "@/components/ui/spotlight-card";
 import { getContentIcon } from "@/lib/icon-registry";
+import { PUBLIC_SUPPORT_EMAIL } from "@/lib/site-url";
 import { trackEvent } from "@/lib/umami";
 import { cn } from "@/lib/utils";
 import { hireRequestService } from "@/services";
@@ -176,7 +177,7 @@ export function HireMeView({
 		onError: () => {
 			toast({
 				title: "Error",
-				description: "Failed to send your inquiry. Please try again or email hi@wismannur.pro directly.",
+				description: `Failed to send your inquiry. Please try again or email ${PUBLIC_SUPPORT_EMAIL} directly.`,
 				variant: "destructive",
 			});
 			trackEvent("hire-me-form-submit-error");

--- a/src/app/api/webhooks/resend-inbound/route.ts
+++ b/src/app/api/webhooks/resend-inbound/route.ts
@@ -4,9 +4,51 @@ import { Resend } from "resend";
 import { Webhook } from "svix";
 
 import { getDb, schema } from "@/db";
-import { sendInboundAlertToAdmin } from "@/services/core/resend";
+import { RESEND_EMAIL_DOMAIN, sendInboundAlertToAdmin } from "@/services/core/resend";
 
 const { contacts, serviceRequests, hireRequests, inquiryMessages, jobOutreaches, jobOutreachMessages } = schema;
+
+function extractRecipientEmails(rawTo: unknown): string[] {
+	if (!rawTo) return [];
+	const toList = Array.isArray(rawTo) ? rawTo : [rawTo];
+	const emails: string[] = [];
+	for (const item of toList) {
+		if (typeof item === "string") {
+			const match = item.match(/<([^>]+)>/);
+			const clean = (match ? match[1] : item).trim().toLowerCase();
+			if (clean) emails.push(clean);
+		} else if (typeof item === "object" && item !== null) {
+			const obj = item as Record<string, unknown>;
+			const email = String(obj.email || obj.address || "").trim().toLowerCase();
+			if (email) emails.push(email);
+		}
+	}
+	return emails;
+}
+
+function isRecipientMatchingDomain(recipients: string[], targetDomain: string): boolean {
+	if (recipients.length === 0) return true;
+	const normalizedTarget = targetDomain.trim().toLowerCase();
+
+	return recipients.some((email) => {
+		const atIndex = email.lastIndexOf("@");
+		if (atIndex === -1) return false;
+		const domainPart = email.slice(atIndex + 1).trim().toLowerCase();
+		if (!domainPart) return false;
+
+		// Exact match
+		if (domainPart === normalizedTarget) return true;
+
+		// If current environment is Prod ("wismannur.pro"):
+		// Must strictly be wismannur.pro or www.wismannur.pro, and NOT a development subdomain like dev.wismannur.pro
+		if (normalizedTarget === "wismannur.pro") {
+			return domainPart === "wismannur.pro" || domainPart === "www.wismannur.pro";
+		}
+
+		// If current environment is Dev ("dev.wismannur.pro"):
+		return domainPart === normalizedTarget || domainPart.endsWith(`.${normalizedTarget}`);
+	});
+}
 
 
 function extractCleanEmail(rawFrom: unknown): { name: string; email: string } {
@@ -247,8 +289,29 @@ export async function POST(req: NextRequest) {
 			return NextResponse.json({ message: "Sender email missing, skipped" }, { status: 200 });
 		}
 
+		// 5. Defense-in-Depth: Filter out emails intended for another environment (e.g. Dev receiving Prod or Prod receiving Dev)
+		const rawTo = data.to || fullEmail?.to || data.recipient || body.to;
+		const recipientEmails = extractRecipientEmails(rawTo);
+		const currentEnvDomain = (process.env.RESEND_EMAIL_DOMAIN || "wismannur.pro").trim().toLowerCase();
+
+		if (recipientEmails.length > 0 && !isRecipientMatchingDomain(recipientEmails, currentEnvDomain)) {
+			console.log(
+				`[Resend Inbound] Recipient(s) [${recipientEmails.join(", ")}] do not belong to current environment domain (${currentEnvDomain}). Safely ignoring event.`
+			);
+			return NextResponse.json(
+				{
+					success: true,
+					skipped: true,
+					reason: "environment_domain_mismatch",
+					recipients: recipientEmails,
+					expectedDomain: currentEnvDomain,
+				},
+				{ status: 200 },
+			);
+		}
+
 		const db = getDb();
-		const toInfo = extractIdFromToAddress(data.to || fullEmail?.to || data.recipient || body.to);
+		const toInfo = extractIdFromToAddress(rawTo);
 		const emailHeaders = (fullEmail?.headers || {}) as Record<string, unknown>;
 		const headerRefId =
 			typeof emailHeaders["x-entity-ref-id"] === "string"
@@ -677,7 +740,6 @@ export async function POST(req: NextRequest) {
 				.where(eq(hireRequests.id, targetInquiryId));
 		}
 
-		const rawTo = data.to || fullEmail?.to || data.recipient || body.to;
 		const recipientTo = Array.isArray(rawTo)
 			? rawTo
 					.map((item) =>
@@ -691,7 +753,7 @@ export async function POST(req: NextRequest) {
 					.join(", ")
 			: typeof rawTo === "string"
 				? rawTo
-				: "hi@wismannur.pro";
+				: `hi@${currentEnvDomain}`;
 
 		// 10. Send email alert to Admin
 		await sendInboundAlertToAdmin({
@@ -701,7 +763,7 @@ export async function POST(req: NextRequest) {
 			clientEmail: senderEmail,
 			subject: targetSubject,
 			message: textContent,
-			toAddress: recipientTo || "hi@wismannur.pro",
+			toAddress: recipientTo || `hi@${currentEnvDomain}`,
 			isNewConversation: isNewInquiry,
 		});
 

--- a/src/app/cms/contacts/[id]/page.tsx
+++ b/src/app/cms/contacts/[id]/page.tsx
@@ -28,6 +28,8 @@ import { useParams, useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 
+import { PUBLIC_SUPPORT_EMAIL } from "@/lib/site-url";
+
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -408,7 +410,7 @@ export default function ContactDetailPage() {
 										<span>Kirim Balasan Email ke Klien</span>
 									</label>
 									<span className="text-[11px] text-muted-foreground">
-										Pengirim: <strong className="text-primary font-medium">hi@wismannur.pro</strong>
+										Pengirim: <strong className="text-primary font-medium">{PUBLIC_SUPPORT_EMAIL}</strong>
 									</span>
 								</div>
 

--- a/src/app/cms/job-outreaches/[id]/page.tsx
+++ b/src/app/cms/job-outreaches/[id]/page.tsx
@@ -29,6 +29,8 @@ import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { toast } from "sonner";
 
+import { PUBLIC_SUPPORT_EMAIL } from "@/lib/site-url";
+
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -132,7 +134,7 @@ export default function JobOutreachDetailPage() {
 		setIsSendingDraft(true);
 		try {
 			await jobOutreachService.sendEmail(outreach.id);
-			toast.success(`Email berhasil dikirim ke ${outreach.contactEmail} via hi@wismannur.pro!`);
+			toast.success(`Email berhasil dikirim ke ${outreach.contactEmail} via ${PUBLIC_SUPPORT_EMAIL}!`);
 			refetch();
 			queryClient.invalidateQueries({ queryKey: ["jobOutreaches"] });
 			queryClient.invalidateQueries({ queryKey: ["jobOutreachesAnalytics"] });
@@ -374,7 +376,7 @@ export default function JobOutreachDetailPage() {
 										Outreach ini masih berstatus Draf
 									</div>
 									<p className="text-xs text-muted-foreground">
-										Email belum dikirimkan ke <strong className="text-foreground">{outreach.contactName}</strong> ({outreach.contactEmail}). Klik tombol di samping untuk mengirimkannya langsung via <strong className="text-primary font-mono">hi@wismannur.pro</strong>.
+										Email belum dikirimkan ke <strong className="text-foreground">{outreach.contactName}</strong> ({outreach.contactEmail}). Klik tombol di samping untuk mengirimkannya langsung via <strong className="text-primary font-mono">{PUBLIC_SUPPORT_EMAIL}</strong>.
 									</p>
 								</div>
 							</div>
@@ -407,7 +409,7 @@ export default function JobOutreachDetailPage() {
 									</CardTitle>
 
 									<CardDescription className="text-xs">
-										Ref ID: <span className="font-mono text-foreground font-semibold">#{outreach.id}</span> · Pengiriman dari <span className="text-primary font-mono">hi@wismannur.pro</span>
+										Ref ID: <span className="font-mono text-foreground font-semibold">#{outreach.id}</span> · Pengiriman dari <span className="text-primary font-mono">{PUBLIC_SUPPORT_EMAIL}</span>
 									</CardDescription>
 								</div>
 								<Badge variant="outline" className={cn("text-xs font-semibold", statusInfo.className)}>
@@ -529,7 +531,7 @@ export default function JobOutreachDetailPage() {
 
 								<div className="flex items-center justify-between pt-1">
 									<span className="text-xs text-muted-foreground">
-										Mengirim dari <strong className="text-foreground">hi@wismannur.pro</strong>
+										Mengirim dari <strong className="text-foreground">{PUBLIC_SUPPORT_EMAIL}</strong>
 									</span>
 									<Button
 										onClick={handleSendFollowUp}

--- a/src/app/cms/job-outreaches/new/page.tsx
+++ b/src/app/cms/job-outreaches/new/page.tsx
@@ -23,6 +23,8 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 
+import { PUBLIC_SUPPORT_EMAIL } from "@/lib/site-url";
+
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -220,7 +222,7 @@ export default function NewOutreachPage() {
 
 			toast.success(
 				sendImmediately
-					? `Email berhasil dikirim ke ${contactEmail} via hi@wismannur.pro!`
+					? `Email berhasil dikirim ke ${contactEmail} via ${PUBLIC_SUPPORT_EMAIL}!`
 					: "Draf outreach berhasil disimpan.",
 			);
 
@@ -261,7 +263,7 @@ export default function NewOutreachPage() {
 						New Job Outreach & Cold Pitch
 					</h1>
 					<p className="text-xs sm:text-sm text-muted-foreground mt-1">
-						Kirim pesan langsung ke recruiter / engineering lead via <strong className="text-foreground">hi@wismannur.pro</strong>.
+						Kirim pesan langsung ke recruiter / engineering lead via <strong className="text-foreground">{PUBLIC_SUPPORT_EMAIL}</strong>.
 					</p>
 				</div>
 
@@ -619,7 +621,7 @@ export default function NewOutreachPage() {
 									Email Composer
 								</CardTitle>
 								<span className="text-[11px] text-muted-foreground font-mono">
-									From: <span className="text-primary font-semibold">Wisman Nur &lt;hi@wismannur.pro&gt;</span>
+									From: <span className="text-primary font-semibold">Wisman Nur &lt;{PUBLIC_SUPPORT_EMAIL}&gt;</span>
 								</span>
 							</div>
 						</CardHeader>

--- a/src/app/cms/job-outreaches/page.tsx
+++ b/src/app/cms/job-outreaches/page.tsx
@@ -28,6 +28,8 @@ import {
 import Link from "next/link";
 import { toast } from "sonner";
 
+import { PUBLIC_SUPPORT_EMAIL } from "@/lib/site-url";
+
 
 
 import {
@@ -183,7 +185,7 @@ export default function JobOutreachesPage() {
 	const handleSendDraft = async (id: string, contactEmail: string) => {
 		try {
 			await jobOutreachService.sendEmail(id);
-			toast.success(`Email berhasil dikirim ke ${contactEmail} via hi@wismannur.pro!`);
+			toast.success(`Email berhasil dikirim ke ${contactEmail} via ${PUBLIC_SUPPORT_EMAIL}!`);
 			queryClient.invalidateQueries({ queryKey: ["jobOutreaches"] });
 			queryClient.invalidateQueries({ queryKey: ["jobOutreachesAnalytics"] });
 		} catch (err) {
@@ -203,7 +205,7 @@ export default function JobOutreachesPage() {
 					</h1>
 					<p className="text-sm text-muted-foreground mt-1">
 						Kelola cold outreach, direct application via email, dan pantau balasan dari recruiter secara terintegrasi melalui{" "}
-						<strong className="text-foreground">hi@wismannur.pro</strong>.
+						<strong className="text-foreground">{PUBLIC_SUPPORT_EMAIL}</strong>.
 					</p>
 				</div>
 

--- a/src/app/cms/job-tracker/[id]/job-application-detail.tsx
+++ b/src/app/cms/job-tracker/[id]/job-application-detail.tsx
@@ -32,6 +32,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 
+import { PUBLIC_SUPPORT_EMAIL } from "@/lib/site-url";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -1180,7 +1181,7 @@ export function JobApplicationDetail({ initialId }: { initialId: string }) {
 									Outreach & Cold Email Communications
 								</CardTitle>
 								<CardDescription className="text-xs">
-									Lacak direct applications, cold pitches, dan percakapan balasan dari recruiter untuk <strong>{currentApp.companyName}</strong> via <strong className="text-foreground">hi@wismannur.pro</strong>.
+									Lacak direct applications, cold pitches, dan percakapan balasan dari recruiter untuk <strong>{currentApp.companyName}</strong> via <strong className="text-foreground">{PUBLIC_SUPPORT_EMAIL}</strong>.
 								</CardDescription>
 							</div>
 

--- a/src/app/cms/services/[id]/page.tsx
+++ b/src/app/cms/services/[id]/page.tsx
@@ -37,6 +37,8 @@ import { useParams, useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 
+import { PUBLIC_SUPPORT_EMAIL } from "@/lib/site-url";
+
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -507,7 +509,7 @@ export default function ServiceRequestDetailPage() {
 										<span>Kirim Balasan Email ke Klien</span>
 									</label>
 									<span className="text-[11px] text-muted-foreground">
-										Pengirim: <strong className="text-primary font-medium">hi@wismannur.pro</strong>
+										Pengirim: <strong className="text-primary font-medium">{PUBLIC_SUPPORT_EMAIL}</strong>
 									</span>
 								</div>
 

--- a/src/app/cv/cv-view.tsx
+++ b/src/app/cv/cv-view.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useTheme } from "@/hooks/use-theme";
 import { formatResumePeriod } from "@/lib/resume";
+import { PUBLIC_SUPPORT_EMAIL } from "@/lib/site-url";
 import { trackEvent } from "@/lib/umami";
 import { cn } from "@/lib/utils";
 import type { ResumeEntry } from "@/services/resume/types";
@@ -121,7 +122,7 @@ export function CVView({ user, experiences, education, skills, settings }: CVVie
 	const { isDark, setTheme } = useTheme();
 
 	const name = user?.displayName || settings.siteName || "Wisman Nur";
-	const email = user?.email || settings.publicEmail || "hi@wismannur.pro";
+	const email = user?.email || settings.publicEmail || PUBLIC_SUPPORT_EMAIL;
 	const location = user?.location || settings.location || "Indonesia";
 	const website = user?.website || "https://wismannur.pro";
 	const github = user?.social?.github || settings.social?.github;

--- a/src/components/detail/author-bio.tsx
+++ b/src/components/detail/author-bio.tsx
@@ -16,6 +16,7 @@ import {
 	MessageCircle,
 	Sparkles,
 } from "lucide-react";
+import { PUBLIC_SUPPORT_EMAIL } from "@/lib/site-url";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
@@ -40,7 +41,7 @@ const AuthorBio = () => {
 			url: authorData?.social.github || "https://github.com/wismannur",
 			icon: <Github size={15} />,
 		},
-		{ name: "Email", url: `mailto:${authorData?.email || "hi@wismannur.pro"}`, icon: <Mail size={15} /> },
+		{ name: "Email", url: `mailto:${authorData?.email || PUBLIC_SUPPORT_EMAIL}`, icon: <Mail size={15} /> },
 	];
 
 	return (

--- a/src/components/emails/admin-direct-email-alert.tsx
+++ b/src/components/emails/admin-direct-email-alert.tsx
@@ -12,6 +12,8 @@ import {
 	Text,
 } from "@react-email/components";
 
+import { PUBLIC_SUPPORT_EMAIL } from "@/lib/site-url";
+
 export interface AdminDirectEmailAlertProps {
 	inquiryId: string;
 	clientName: string;
@@ -28,7 +30,7 @@ export const AdminDirectEmailAlertEmail = ({
 	clientEmail,
 	subject,
 	message,
-	toAddress = "hi@wismannur.pro",
+	toAddress = PUBLIC_SUPPORT_EMAIL,
 	receivedAt = new Date().toLocaleString("id-ID", { timeZone: "Asia/Jakarta" }),
 }: AdminDirectEmailAlertProps) => {
 	const previewText = `[New Direct Email] ${subject} dari ${clientName}`;

--- a/src/components/emails/job-outreach-email.tsx
+++ b/src/components/emails/job-outreach-email.tsx
@@ -10,6 +10,7 @@ import {
 	Section,
 	Text,
 } from "@react-email/components";
+import { PUBLIC_SUPPORT_EMAIL } from "@/lib/site-url";
 
 interface JobOutreachEmailProps {
 	contactName: string;
@@ -83,8 +84,8 @@ export const JobOutreachEmail = ({
 					<Section style={footerSection}>
 						<Text style={footerText}>
 							Sent directly from Wisman Nur (
-							<Link href="mailto:hi@wismannur.pro" style={linkStyle}>
-								hi@wismannur.pro
+							<Link href={`mailto:${PUBLIC_SUPPORT_EMAIL}`} style={linkStyle}>
+								{PUBLIC_SUPPORT_EMAIL}
 							</Link>
 							). Feel free to reply directly to this email.
 						</Text>

--- a/src/lib/site-url.ts
+++ b/src/lib/site-url.ts
@@ -2,3 +2,11 @@
 // robots). Env-level rather than DB because robots/sitemap resolve it at
 // build time and it never changes without a redeploy anyway.
 export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.wismannur.pro";
+
+export const RESEND_EMAIL_DOMAIN =
+	process.env.NEXT_PUBLIC_RESEND_EMAIL_DOMAIN ||
+	process.env.RESEND_EMAIL_DOMAIN ||
+	"wismannur.pro";
+
+export const PUBLIC_SUPPORT_EMAIL = `hi@${RESEND_EMAIL_DOMAIN}`;
+

--- a/src/services/core/resend.ts
+++ b/src/services/core/resend.ts
@@ -17,18 +17,23 @@ function getResendClient(): Resend | null {
 	return resendApiKey ? new Resend(resendApiKey) : null;
 }
 
+export const RESEND_EMAIL_DOMAIN =
+	process.env.RESEND_EMAIL_DOMAIN?.trim() ||
+	process.env.NEXT_PUBLIC_RESEND_EMAIL_DOMAIN?.trim() ||
+	"wismannur.pro";
+
 const ADMIN_EMAIL =
 	process.env.ADMIN_NOTIFICATION_EMAIL ||
 	process.env.ADMIN_EMAIL ||
 	"wismannur.pro@gmail.com";
 
 const SENDER_NOTIFICATIONS =
-	process.env.RESEND_FROM_NOTIFICATIONS || "Wisman Nur <notifications@wismannur.pro>";
+	process.env.RESEND_FROM_NOTIFICATIONS || `Wisman Nur <notifications@${RESEND_EMAIL_DOMAIN}>`;
 
 const SENDER_HI =
 	process.env.RESEND_FROM_HI ||
 	process.env.RESEND_FROM_HELLO ||
-	"Wisman Nur <hi@wismannur.pro>";
+	`Wisman Nur <hi@${RESEND_EMAIL_DOMAIN}>`;
 
 interface ContactEmailPayload {
 	id?: string;
@@ -162,7 +167,7 @@ export async function sendContactEmails(
 
 	try {
 		const sentAt = new Date().toLocaleString("id-ID", { timeZone: "Asia/Jakarta" });
-		const dynamicReplyTo = payload.id ? `${payload.id}@wismannur.pro` : "hi@wismannur.pro";
+		const dynamicReplyTo = payload.id ? `${payload.id}@${RESEND_EMAIL_DOMAIN}` : `hi@${RESEND_EMAIL_DOMAIN}`;
 
 		const [adminRes, clientRes] = await Promise.allSettled([
 			// 1. Notification to Admin
@@ -224,7 +229,7 @@ export async function sendServiceRequestEmails(
 
 	try {
 		const sentAt = new Date().toLocaleString("id-ID", { timeZone: "Asia/Jakarta" });
-		const dynamicReplyTo = payload.id ? `${payload.id}@wismannur.pro` : "hi@wismannur.pro";
+		const dynamicReplyTo = payload.id ? `${payload.id}@${RESEND_EMAIL_DOMAIN}` : `hi@${RESEND_EMAIL_DOMAIN}`;
 
 		const [adminRes, clientRes] = await Promise.allSettled([
 			// 1. Notification to Admin
@@ -291,7 +296,7 @@ export async function sendHireRequestEmails(
 
 	try {
 		const sentAt = new Date().toLocaleString("id-ID", { timeZone: "Asia/Jakarta" });
-		const dynamicReplyTo = payload.id ? `${payload.id}@wismannur.pro` : "hi@wismannur.pro";
+		const dynamicReplyTo = payload.id ? `${payload.id}@${RESEND_EMAIL_DOMAIN}` : `hi@${RESEND_EMAIL_DOMAIN}`;
 
 		const [adminRes, clientRes] = await Promise.allSettled([
 			// 1. Notification to Admin
@@ -371,7 +376,7 @@ export async function sendAdminReplyToClient(payload: AdminReplyPayload): Promis
 		const { data, error } = await resend.emails.send({
 			from: SENDER_HI,
 			to: payload.toEmail,
-			replyTo: payload.inquiryId ? `${payload.inquiryId}@wismannur.pro` : "hi@wismannur.pro",
+			replyTo: payload.inquiryId ? `${payload.inquiryId}@${RESEND_EMAIL_DOMAIN}` : `hi@${RESEND_EMAIL_DOMAIN}`,
 			subject: formattedSubject,
 			headers,
 			react: AdminReplyToClientEmail({
@@ -473,7 +478,7 @@ export async function sendJobOutreachEmail(payload: JobOutreachSendPayload): Pro
 		const { data, error } = await resend.emails.send({
 			from: SENDER_HI,
 			to: payload.toEmail,
-			replyTo: payload.outreachId ? `${payload.outreachId}@wismannur.pro` : "hi@wismannur.pro",
+			replyTo: payload.outreachId ? `${payload.outreachId}@${RESEND_EMAIL_DOMAIN}` : `hi@${RESEND_EMAIL_DOMAIN}`,
 			subject: formattedSubject,
 			attachments: resendAttachments,
 			headers,

--- a/src/services/inquiry-messages/actions.ts
+++ b/src/services/inquiry-messages/actions.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import { getDb, schema } from "@/db";
 import { assertAdmin } from "../core/auth-guard";
 import { ServiceError } from "../core/base-service";
-import { sendAdminReplyToClient } from "../core/resend";
+import { RESEND_EMAIL_DOMAIN, sendAdminReplyToClient } from "../core/resend";
 import type { InquiryMessage, SendAdminReplyInput } from "./types";
 
 const { inquiryMessages, contacts, serviceRequests, hireRequests } = schema;
@@ -115,7 +115,7 @@ export async function sendAdminReply(data: SendAdminReplyInput): Promise<Inquiry
 			inquiryType: clean.inquiryType,
 			senderType: "admin",
 			senderName: "Wisman Nur",
-			senderEmail: "hi@wismannur.pro",
+			senderEmail: `hi@${RESEND_EMAIL_DOMAIN}`,
 			message: clean.message,
 			messageId: sendRes.id || null,
 		})

--- a/src/services/job-outreaches/actions.ts
+++ b/src/services/job-outreaches/actions.ts
@@ -11,7 +11,7 @@ import type {
 	JobOutreachRow,
 } from "@/db/schema";
 import { assertAdmin } from "../core/auth-guard";
-import { sendJobOutreachEmail } from "../core/resend";
+import { RESEND_EMAIL_DOMAIN, sendJobOutreachEmail } from "../core/resend";
 import { generateOutreachDraftWithGemini } from "./gemini-ai";
 import type {
 	AiOutreachDraftParams,
@@ -287,7 +287,7 @@ export async function createJobOutreach(
 			outreachId: inserted.id,
 			senderType: "admin",
 			senderName: "Wisman Nur",
-			senderEmail: "hi@wismannur.pro",
+			senderEmail: `hi@${RESEND_EMAIL_DOMAIN}`,
 			message: inserted.body,
 			messageId: resendId || null,
 			createdAt: isSending ? now : inserted.createdAt,
@@ -469,7 +469,7 @@ export async function sendFollowUpMessage(
 			outreachId,
 			senderType: "admin",
 			senderName: "Wisman Nur",
-			senderEmail: "hi@wismannur.pro",
+			senderEmail: `hi@${RESEND_EMAIL_DOMAIN}`,
 			message: followUpText.trim(),
 			messageId: sendRes.id || null,
 		})

--- a/src/services/site-settings/defaults.ts
+++ b/src/services/site-settings/defaults.ts
@@ -1,3 +1,4 @@
+import { PUBLIC_SUPPORT_EMAIL } from "@/lib/site-url";
 import type { SiteSettings } from "./types";
 
 // Mirror of the seeded row — the fallback if the row is missing (fresh DB
@@ -23,7 +24,7 @@ export const DEFAULT_SITE_SETTINGS: SiteSettings = {
 	ogTitle: "Frontend Software Engineer",
 	ogTagline:
 		"High-performance web applications, seamless API integrations, and intuitive user experiences.",
-	publicEmail: "hi@wismannur.pro",
+	publicEmail: PUBLIC_SUPPORT_EMAIL,
 	location: "Bandung, West Java, Indonesia",
 	timezoneLabel: "Western Indonesian Time, UTC+07:00",
 	social: {


### PR DESCRIPTION
## Summary
- Implements defense-in-depth recipient domain filtering on Resend inbound email webhook to prevent cross-environment event processing between \`wismannur.pro\` (prod) and \`dev.wismannur.pro\` (dev).
- Dynamically configures sender and reply-to email addresses (\`notifications@...\`, \`hi@...\`, \`contact-xxx@...\`, \`outreach-xxx@...\`) using \`RESEND_EMAIL_DOMAIN\` environment variable.
- Replaces hardcoded \`hi@wismannur.pro\` occurrences across CMS, email templates, and public pages with dynamic \`PUBLIC_SUPPORT_EMAIL\`.

## Changes
- **feat(email)**: add defense-in-depth recipient domain filtering for multi-env inbound routing (\`c7b38e0\`)
- **refactor(email)**: use dynamic public support email in email templates and default settings (\`89af232\`)
- **refactor(cms)**: align frontend and cms email labels with dynamic email domain (\`efa3812\`)

## Test plan
- [x] Run \`npm run build\` with full TypeScript type check and page pre-rendering (55/55 static pages generated, exit code 0).
- [x] Verify recipient extraction & domain check logic in webhook route.