### PR TITLE
feat(inbound): clean email bodies and translate cms and emails to english

### DIFF
--- a/src/app/api/webhooks/resend-inbound/route.ts
+++ b/src/app/api/webhooks/resend-inbound/route.ts
@@ -4,7 +4,8 @@ import { Resend } from "resend";
 import { Webhook } from "svix";
 
 import { getDb, schema } from "@/db";
-import { RESEND_EMAIL_DOMAIN, sendInboundAlertToAdmin } from "@/services/core/resend";
+import { cleanReplyBody } from "@/lib/email-cleaner";
+import { sendInboundAlertToAdmin } from "@/services/core/resend";
 
 const { contacts, serviceRequests, hireRequests, inquiryMessages, jobOutreaches, jobOutreachMessages } = schema;
 
@@ -168,23 +169,6 @@ function htmlToPlainText(html: string): string {
 		.trim();
 }
 
-function cleanReplyBody(text: string): string {
-	if (!text) return "";
-	const lines = text.split("\n");
-	const cleanedLines: string[] = [];
-
-	for (const line of lines) {
-		// Stop at common email quote headers
-		if (line.match(/^On\s.+wrote:$/i)) break;
-		if (line.match(/^Pada\s.+menulis:$/i)) break;
-		if (line.match(/^---+\s*Original Message\s*---+/i)) break;
-		if (line.match(/^_{5,}/)) break;
-		cleanedLines.push(line);
-	}
-
-	const result = cleanedLines.join("\n").trim();
-	return result || text.trim();
-}
 
 export async function POST(req: NextRequest) {
 	try {
@@ -279,7 +263,7 @@ export async function POST(req: NextRequest) {
 			textContent = cleanReplyBody(htmlToPlainText(rawHtml));
 		}
 		if (!textContent) {
-			textContent = rawText.trim() || htmlToPlainText(rawHtml) || subject || "(Pesan masuk tanpa teks)";
+			textContent = rawText.trim() || htmlToPlainText(rawHtml) || subject || "(Inbound message without body)";
 		}
 
 		const { name: senderName, email: senderEmail } = extractCleanEmail(fromRaw);

--- a/src/app/cms/contacts/[id]/page.tsx
+++ b/src/app/cms/contacts/[id]/page.tsx
@@ -119,14 +119,14 @@ export default function ContactDetailPage() {
 				originalMessageSnippet: contact.message,
 			});
 
-			toast.success("Balasan email berhasil dikirim ke klien!");
+			toast.success("Email reply successfully sent to client!");
 			setReplyMessage("");
 			refetchThread();
 			refetchContact();
 			queryClient.invalidateQueries({ queryKey: ["contacts"] });
 		} catch (error) {
 			console.error("Error sending reply:", error);
-			const msg = error instanceof Error ? error.message : "Gagal mengirim balasan email";
+			const msg = error instanceof Error ? error.message : "Failed to send email reply";
 			toast.error(msg);
 		} finally {
 			setIsSendingReply(false);
@@ -151,12 +151,12 @@ export default function ContactDetailPage() {
 		setIsDeleting(true);
 		try {
 			await contactService.delete(contact.id);
-			toast.success("Pesan kontak berhasil dihapus");
+			toast.success("Contact message successfully deleted");
 			queryClient.invalidateQueries({ queryKey: ["contacts"] });
 			router.push("/cms/contacts");
 		} catch (error) {
 			console.error("Error deleting contact:", error);
-			toast.error("Gagal menghapus pesan kontak");
+			toast.error("Failed to delete contact message");
 		} finally {
 			setIsDeleting(false);
 		}
@@ -240,10 +240,10 @@ export default function ContactDetailPage() {
 				<Inbox className="w-12 h-12 text-muted-foreground mx-auto" />
 				<h2 className="text-xl font-semibold">Message Not Found</h2>
 				<p className="text-sm text-muted-foreground">
-					Pesan kontak yang Anda cari tidak ditemukan atau telah dihapus.
+					The contact message you are looking for was not found or has been deleted.
 				</p>
 				<Button asChild variant="outline">
-					<Link href="/cms/contacts">Kembali ke Daftar</Link>
+					<Link href="/cms/contacts">Back to List</Link>
 				</Button>
 			</div>
 		);
@@ -256,7 +256,7 @@ export default function ContactDetailPage() {
 				<Button asChild variant="ghost" size="sm" className="gap-2 -ml-2 text-muted-foreground hover:text-foreground">
 					<Link href="/cms/contacts">
 						<ArrowLeft className="w-4 h-4" />
-						<span>Kembali ke Contact Messages</span>
+						<span>Back to Contact Messages</span>
 					</Link>
 				</Button>
 
@@ -313,7 +313,7 @@ export default function ContactDetailPage() {
 					<p className="text-xs sm:text-sm text-muted-foreground flex flex-wrap items-center gap-1.5 sm:gap-2">
 						<span className="font-medium text-foreground">{contact.subject}</span>
 						<span>•</span>
-						<span>Diterima {format(new Date(contact.createdAt), "dd MMM yyyy, HH:mm")}</span>
+						<span>Received {format(new Date(contact.createdAt), "dd MMM yyyy, HH:mm")}</span>
 					</p>
 				</div>
 			</div>
@@ -328,10 +328,10 @@ export default function ContactDetailPage() {
 							<div className="flex items-center justify-between">
 								<CardTitle className="text-sm font-semibold flex items-center gap-2">
 									<Mail className="w-4 h-4 text-primary" />
-									<span>Pesan Kontak: {contact.subject}</span>
+									<span>Contact Message: {contact.subject}</span>
 								</CardTitle>
 								<Badge variant="outline" className="text-[10px]">
-									Pesan Pertama
+									Original Message
 								</Badge>
 							</div>
 						</CardHeader>
@@ -348,7 +348,7 @@ export default function ContactDetailPage() {
 							<div className="flex items-center justify-between">
 								<CardTitle className="text-sm font-semibold flex items-center gap-2">
 									<MessageSquare className="w-4 h-4 text-primary" />
-									<span>Riwayat Percakapan ({threadMessages.length})</span>
+									<span>Conversation Thread ({threadMessages.length})</span>
 								</CardTitle>
 								<Button
 									variant="ghost"
@@ -364,7 +364,7 @@ export default function ContactDetailPage() {
 						<CardContent className="p-4 sm:p-6 pt-0 space-y-4">
 							{threadMessages.length === 0 ? (
 								<div className="text-center py-8 text-muted-foreground text-xs bg-muted/10 rounded-xl border border-dashed border-border/60">
-									Belum ada balasan email terkirim. Tulis pesan di bawah untuk membalas email ke klien.
+									No email replies sent yet. Write a message below to reply to the client.
 								</div>
 							) : (
 								<div className="space-y-3">
@@ -407,15 +407,15 @@ export default function ContactDetailPage() {
 								<div className="flex flex-wrap justify-between items-center gap-1">
 									<label className="text-xs font-semibold text-foreground flex items-center gap-1.5">
 										<Mail className="h-4 w-4 text-primary" />
-										<span>Kirim Balasan Email ke Klien</span>
+										<span>Send Email Reply to Client</span>
 									</label>
 									<span className="text-[11px] text-muted-foreground">
-										Pengirim: <strong className="text-primary font-medium">{PUBLIC_SUPPORT_EMAIL}</strong>
+										Sender: <strong className="text-primary font-medium">{PUBLIC_SUPPORT_EMAIL}</strong>
 									</span>
 								</div>
 
 								<Textarea
-									placeholder={`Tulis balasan email untuk ${contact.name}... (Akan langsung dikirimkan ke ${contact.email})`}
+									placeholder={`Write an email reply for ${contact.name}... (Will be sent directly to ${contact.email})`}
 									value={replyMessage}
 									onChange={(e) => setReplyMessage(e.target.value)}
 									rows={5}
@@ -424,7 +424,7 @@ export default function ContactDetailPage() {
 
 								<div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2.5">
 									<span className="text-[11px] text-muted-foreground">
-										Klien dapat langsung membalas email Anda via inbox email mereka.
+										Client can reply directly to your email from their inbox.
 									</span>
 									<Button
 										size="sm"
@@ -435,12 +435,12 @@ export default function ContactDetailPage() {
 										{isSendingReply ? (
 											<>
 												<Loader2 className="h-3.5 w-3.5 animate-spin" />
-												<span>Mengirim...</span>
+												<span>Sending...</span>
 											</>
 										) : (
 											<>
 												<Send className="h-3.5 w-3.5" />
-												<span>Kirim Balasan Email</span>
+												<span>Send Email Reply</span>
 											</>
 										)}
 									</Button>
@@ -457,7 +457,7 @@ export default function ContactDetailPage() {
 						<CardHeader className="p-4 sm:p-5 pb-3">
 							<CardTitle className="text-xs font-semibold text-muted-foreground uppercase tracking-wider flex items-center gap-1.5">
 								<User className="h-3.5 w-3.5 text-primary" />
-								<span>Informasi Pengirim</span>
+								<span>Sender Information</span>
 							</CardTitle>
 						</CardHeader>
 						<CardContent className="p-4 sm:p-5 pt-0 space-y-4">
@@ -502,7 +502,7 @@ export default function ContactDetailPage() {
 								</div>
 
 								<div>
-									<div className="text-muted-foreground mb-0.5">Subjek:</div>
+									<div className="text-muted-foreground mb-0.5">Subject:</div>
 									<div className="font-medium text-foreground bg-muted/30 p-2 rounded-lg border border-border/40 text-xs break-words">
 										{contact.subject}
 									</div>
@@ -519,7 +519,7 @@ export default function ContactDetailPage() {
 								<span className="font-mono text-foreground/80 truncate max-w-[160px]">{contact.id}</span>
 							</div>
 							<div className="flex justify-between gap-2">
-								<span>Tanggal Diterima:</span>
+								<span>Received Date:</span>
 								<span className="text-foreground/80 whitespace-nowrap">
 									{format(new Date(contact.createdAt), "dd MMM yyyy HH:mm")}
 								</span>
@@ -533,15 +533,15 @@ export default function ContactDetailPage() {
 			<AlertDialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
 				<AlertDialogContent>
 					<AlertDialogHeader>
-						<AlertDialogTitle>Hapus Pesan Kontak?</AlertDialogTitle>
+						<AlertDialogTitle>Delete Contact Message?</AlertDialogTitle>
 						<AlertDialogDescription>
-							Tindakan ini tidak dapat dibatalkan. Pesan kontak dari{" "}
-							<strong className="text-foreground">{contact.name}</strong> ({contact.email}) beserta
-							seluruh riwayat percakapan email akan dihapus secara permanen.
+							This action cannot be undone. The contact message from{" "}
+							<strong className="text-foreground">{contact.name}</strong> ({contact.email}) and its
+							entire email conversation history will be permanently deleted.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>
-						<AlertDialogCancel disabled={isDeleting}>Batal</AlertDialogCancel>
+						<AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
 						<AlertDialogAction
 							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
 							onClick={handleDelete}
@@ -550,10 +550,10 @@ export default function ContactDetailPage() {
 							{isDeleting ? (
 								<>
 									<Loader2 className="h-4 w-4 mr-2 animate-spin" />
-									Menghapus...
+									Deleting...
 								</>
 							) : (
-								"Hapus Permanen"
+								"Delete Permanently"
 							)}
 						</AlertDialogAction>
 					</AlertDialogFooter>

--- a/src/app/cms/contacts/page.tsx
+++ b/src/app/cms/contacts/page.tsx
@@ -130,12 +130,12 @@ export default function CmsContactsPage() {
 		setIsDeleting(true);
 		try {
 			await contactService.delete(contactToDelete.id);
-			toast.success("Pesan kontak berhasil dihapus");
+			toast.success("Contact message successfully deleted");
 			setContactToDelete(null);
 			refetch();
 		} catch (error) {
 			console.error("Error deleting contact:", error);
-			toast.error("Gagal menghapus pesan kontak");
+			toast.error("Failed to delete contact message");
 		} finally {
 			setIsDeleting(false);
 		}
@@ -528,15 +528,15 @@ export default function CmsContactsPage() {
 			>
 				<AlertDialogContent>
 					<AlertDialogHeader>
-						<AlertDialogTitle>Hapus Pesan Kontak?</AlertDialogTitle>
+						<AlertDialogTitle>Delete Contact Message?</AlertDialogTitle>
 						<AlertDialogDescription>
-							Tindakan ini tidak dapat dibatalkan. Pesan kontak dari{" "}
+							This action cannot be undone. The contact message from{" "}
 							<strong className="text-foreground">{contactToDelete?.name}</strong> (
-							{contactToDelete?.email}) beserta seluruh riwayat balasan email akan dihapus secara permanen.
+							{contactToDelete?.email}) and all related email thread history will be permanently deleted.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>
-						<AlertDialogCancel disabled={isDeleting}>Batal</AlertDialogCancel>
+						<AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
 						<AlertDialogAction
 							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
 							onClick={handleDeleteContact}
@@ -545,10 +545,10 @@ export default function CmsContactsPage() {
 							{isDeleting ? (
 								<>
 									<Loader2 className="h-4 w-4 mr-2 animate-spin" />
-									Menghapus...
+									Deleting...
 								</>
 							) : (
-								"Hapus"
+								"Delete"
 							)}
 						</AlertDialogAction>
 					</AlertDialogFooter>

--- a/src/app/cms/hire-requests/[id]/page.tsx
+++ b/src/app/cms/hire-requests/[id]/page.tsx
@@ -155,19 +155,19 @@ export default function HireRequestDetailPage() {
 				inquiryType: "hire_request",
 				toEmail: request.email,
 				toName: request.name,
-				subject: `Tanggapan Penawaran: ${request.roleTitle} @ ${request.company}`,
+				subject: `Response: ${request.roleTitle} @ ${request.company}`,
 				message: replyMessage.trim(),
 				originalMessageSnippet: request.message,
 			});
 
-			toast.success("Balasan email berhasil dikirim ke recruiter!");
+			toast.success("Email reply successfully sent to recruiter!");
 			setReplyMessage("");
 			refetchThread();
 			refetchRequest();
 			queryClient.invalidateQueries({ queryKey: ["hireRequests"] });
 		} catch (error) {
 			console.error("Error sending reply:", error);
-			const msg = error instanceof Error ? error.message : "Gagal mengirim balasan email";
+			const msg = error instanceof Error ? error.message : "Failed to send email reply";
 			toast.error(msg);
 		} finally {
 			setIsSendingReply(false);
@@ -192,12 +192,12 @@ export default function HireRequestDetailPage() {
 		setIsDeleting(true);
 		try {
 			await hireRequestService.delete(request.id);
-			toast.success("Hire inquiry berhasil dihapus");
+			toast.success("Hire inquiry successfully deleted");
 			queryClient.invalidateQueries({ queryKey: ["hireRequests"] });
 			router.push("/cms/hire-requests");
 		} catch (error) {
 			console.error("Error deleting hire request:", error);
-			toast.error("Gagal menghapus hire inquiry");
+			toast.error("Failed to delete hire inquiry");
 		} finally {
 			setIsDeleting(false);
 		}
@@ -432,8 +432,7 @@ export default function HireRequestDetailPage() {
 								</div>
 							) : threadMessages.length === 0 ? (
 								<div className="p-6 text-center rounded-xl bg-background/40 border border-dashed border-border/60 text-xs text-muted-foreground">
-									Belum ada balasan email yang dikirim. Kirim balasan pertama di bawah untuk memulai
-									percakapan dengan recruiter.
+									No email replies sent yet. Send the first reply below to start the conversation with the recruiter.
 								</div>
 							) : (
 								<div className="space-y-4">

--- a/src/app/cms/job-outreaches/[id]/page.tsx
+++ b/src/app/cms/job-outreaches/[id]/page.tsx
@@ -134,13 +134,13 @@ export default function JobOutreachDetailPage() {
 		setIsSendingDraft(true);
 		try {
 			await jobOutreachService.sendEmail(outreach.id);
-			toast.success(`Email berhasil dikirim ke ${outreach.contactEmail} via ${PUBLIC_SUPPORT_EMAIL}!`);
+			toast.success(`Email successfully sent to ${outreach.contactEmail} via ${PUBLIC_SUPPORT_EMAIL}!`);
 			refetch();
 			queryClient.invalidateQueries({ queryKey: ["jobOutreaches"] });
 			queryClient.invalidateQueries({ queryKey: ["jobOutreachesAnalytics"] });
 		} catch (err) {
 			console.error("Send draft error:", err);
-			toast.error("Gagal mengirim email draf.");
+			toast.error("Failed to send draft email.");
 		} finally {
 			setIsSendingDraft(false);
 		}
@@ -158,13 +158,13 @@ export default function JobOutreachDetailPage() {
 		if (!outreach) return;
 		try {
 			await jobOutreachService.update(outreach.id, { status: newStatus });
-			toast.success(`Status diubah menjadi ${STATUS_CONFIG[newStatus]?.label || newStatus}`);
+			toast.success(`Status changed to ${STATUS_CONFIG[newStatus]?.label || newStatus}`);
 			queryClient.invalidateQueries({ queryKey: ["jobOutreachDetail", outreachId] });
 			queryClient.invalidateQueries({ queryKey: ["jobOutreaches"] });
 			queryClient.invalidateQueries({ queryKey: ["jobOutreachesAnalytics"] });
 		} catch (err) {
 			console.error("Status update error:", err);
-			toast.error("Gagal mengubah status.");
+			toast.error("Failed to update status.");
 		}
 	};
 
@@ -182,10 +182,10 @@ export default function JobOutreachDetailPage() {
 			});
 
 			setFollowUpMessage(res.body);
-			toast.success("Draf follow-up berhasil dibuat oleh AI!");
+			toast.success("AI follow-up draft generated successfully!");
 		} catch (err) {
 			console.error("AI Follow-up error:", err);
-			toast.error("Gagal men-generate follow up AI.");
+			toast.error("Failed to generate AI follow-up.");
 		} finally {
 			setIsGeneratingAiFollowUp(false);
 		}
@@ -196,14 +196,14 @@ export default function JobOutreachDetailPage() {
 		setIsSendingFollowUp(true);
 		try {
 			await jobOutreachService.sendFollowUp(outreach.id, followUpMessage.trim());
-			toast.success(`Follow-up berhasil dikirim ke ${outreach.contactEmail}!`);
+			toast.success(`Follow-up successfully sent to ${outreach.contactEmail}!`);
 			setFollowUpMessage("");
 			refetch();
 			queryClient.invalidateQueries({ queryKey: ["jobOutreaches"] });
 			queryClient.invalidateQueries({ queryKey: ["jobOutreachesAnalytics"] });
 		} catch (err) {
 			console.error("Send follow-up error:", err);
-			toast.error("Gagal mengirim email follow-up.");
+			toast.error("Failed to send follow-up email.");
 		} finally {
 			setIsSendingFollowUp(false);
 		}
@@ -214,14 +214,14 @@ export default function JobOutreachDetailPage() {
 		setIsConverting(true);
 		try {
 			const result = await jobOutreachService.convertToJobApplication(outreach.id);
-			toast.success("Berhasil dihubungkan ke Job Tracker!");
+			toast.success("Successfully connected to Job Tracker!");
 			refetch();
 			queryClient.invalidateQueries({ queryKey: ["jobOutreaches"] });
 			queryClient.invalidateQueries({ queryKey: ["jobTrackerApplications"] });
 			router.push(`/cms/job-tracker/${result.applicationId}`);
 		} catch (err) {
 			console.error("Convert to job tracker error:", err);
-			toast.error("Gagal mengonversi ke Job Tracker.");
+			toast.error("Failed to convert to Job Tracker.");
 		} finally {
 			setIsConverting(false);
 		}
@@ -232,13 +232,13 @@ export default function JobOutreachDetailPage() {
 		setIsDeleting(true);
 		try {
 			await jobOutreachService.delete(outreach.id);
-			toast.success("Outreach berhasil dihapus.");
+			toast.success("Outreach successfully deleted.");
 			queryClient.invalidateQueries({ queryKey: ["jobOutreaches"] });
 			queryClient.invalidateQueries({ queryKey: ["jobOutreachesAnalytics"] });
 			router.push("/cms/job-outreaches");
 		} catch (err) {
 			console.error("Delete error:", err);
-			toast.error("Gagal menghapus outreach.");
+			toast.error("Failed to delete outreach.");
 		} finally {
 			setIsDeleting(false);
 		}
@@ -269,9 +269,9 @@ export default function JobOutreachDetailPage() {
 		return (
 			<div className="text-center py-16 space-y-4">
 				<AlertCircle className="h-12 w-12 text-muted-foreground mx-auto" />
-				<h2 className="text-xl font-bold">Outreach tidak ditemukan</h2>
+				<h2 className="text-xl font-bold">Outreach Not Found</h2>
 				<Button asChild variant="outline">
-					<Link href="/cms/job-outreaches">Kembali ke Daftar Outreach</Link>
+					<Link href="/cms/job-outreaches">Back to Outreach List</Link>
 				</Button>
 			</div>
 		);
@@ -290,7 +290,7 @@ export default function JobOutreachDetailPage() {
 					className="gap-2 -ml-2 text-muted-foreground hover:text-foreground text-xs font-medium"
 				>
 					<Link href="/cms/job-outreaches">
-						<ArrowLeft className="h-4 w-4" /> Kembali ke Job Outreaches
+						<ArrowLeft className="h-4 w-4" /> Back to Job Outreaches
 					</Link>
 				</Button>
 			</div>
@@ -353,7 +353,7 @@ export default function JobOutreachDetailPage() {
 						size="icon"
 						onClick={() => setIsDeleteDialogOpen(true)}
 						className="h-9 w-9 rounded-lg"
-						title="Hapus Outreach"
+						title="Delete Outreach"
 					>
 						<Trash2 className="h-4 w-4" />
 					</Button>
@@ -373,10 +373,10 @@ export default function JobOutreachDetailPage() {
 								</div>
 								<div className="space-y-0.5">
 									<div className="text-sm font-bold text-foreground">
-										Outreach ini masih berstatus Draf
+										This outreach is still a draft
 									</div>
 									<p className="text-xs text-muted-foreground">
-										Email belum dikirimkan ke <strong className="text-foreground">{outreach.contactName}</strong> ({outreach.contactEmail}). Klik tombol di samping untuk mengirimkannya langsung via <strong className="text-primary font-mono">{PUBLIC_SUPPORT_EMAIL}</strong>.
+										Email has not been sent to <strong className="text-foreground">{outreach.contactName}</strong> ({outreach.contactEmail}) yet. Click the button to send it directly via <strong className="text-primary font-mono">{PUBLIC_SUPPORT_EMAIL}</strong>.
 									</p>
 								</div>
 							</div>
@@ -387,11 +387,11 @@ export default function JobOutreachDetailPage() {
 							>
 								{isSendingDraft ? (
 									<>
-										<Loader2 className="h-4 w-4 animate-spin" /> Mengirim...
+										<Loader2 className="h-4 w-4 animate-spin" /> Sending...
 									</>
 								) : (
 									<>
-										<Send className="h-4 w-4" /> Kirim Email Sekarang
+										<Send className="h-4 w-4" /> Send Email Now
 									</>
 								)}
 							</Button>
@@ -409,7 +409,7 @@ export default function JobOutreachDetailPage() {
 									</CardTitle>
 
 									<CardDescription className="text-xs">
-										Ref ID: <span className="font-mono text-foreground font-semibold">#{outreach.id}</span> · Pengiriman dari <span className="text-primary font-mono">{PUBLIC_SUPPORT_EMAIL}</span>
+										Ref ID: <span className="font-mono text-foreground font-semibold">#{outreach.id}</span> · Sent from <span className="text-primary font-mono">{PUBLIC_SUPPORT_EMAIL}</span>
 									</CardDescription>
 								</div>
 								<Badge variant="outline" className={cn("text-xs font-semibold", statusInfo.className)}>
@@ -430,7 +430,7 @@ export default function JobOutreachDetailPage() {
 													WN
 												</AvatarFallback>
 											</Avatar>
-											<span>Wisman Nur (Anda)</span>
+											<span>Wisman Nur (You)</span>
 										</div>
 										<span>{outreach.sentAt ? format(new Date(outreach.sentAt), "dd MMM yyyy, HH:mm") : "Draft"}</span>
 									</div>
@@ -523,7 +523,7 @@ export default function JobOutreachDetailPage() {
 
 								<Textarea
 									rows={5}
-									placeholder={`Tulis pesan balasan atau follow-up untuk ${outreach.contactName}...`}
+									placeholder={`Write a reply or follow-up message for ${outreach.contactName}...`}
 									value={followUpMessage}
 									onChange={(e) => setFollowUpMessage(e.target.value)}
 									className="text-sm leading-relaxed"
@@ -531,7 +531,7 @@ export default function JobOutreachDetailPage() {
 
 								<div className="flex items-center justify-between pt-1">
 									<span className="text-xs text-muted-foreground">
-										Mengirim dari <strong className="text-foreground">{PUBLIC_SUPPORT_EMAIL}</strong>
+										Sending from <strong className="text-foreground">{PUBLIC_SUPPORT_EMAIL}</strong>
 									</span>
 									<Button
 										onClick={handleSendFollowUp}
@@ -540,11 +540,11 @@ export default function JobOutreachDetailPage() {
 									>
 										{isSendingFollowUp ? (
 											<>
-												<Loader2 className="h-4 w-4 animate-spin" /> Mengirim...
+												<Loader2 className="h-4 w-4 animate-spin" /> Sending...
 											</>
 										) : (
 											<>
-												<Send className="h-4 w-4" /> Kirim via Resend
+												<Send className="h-4 w-4" /> Send via Resend
 											</>
 										)}
 									</Button>
@@ -656,14 +656,14 @@ export default function JobOutreachDetailPage() {
 										className="w-full text-xs h-8 gap-1.5 mt-2"
 									>
 										<Link href={`/cms/job-tracker/${outreach.jobApplication.id}`}>
-											<Briefcase className="h-3.5 w-3.5" /> Buka di Job Tracker
+											<Briefcase className="h-3.5 w-3.5" /> Open in Job Tracker
 										</Link>
 									</Button>
 								</div>
 							) : (
 								<div className="space-y-3 text-xs text-muted-foreground">
 									<p>
-										Outreach ini belum terhubung dengan data di Job Tracker. Jika recruiter membalas positif, Anda dapat langsung mengonversinya menjadi aplikasi/interview aktif.
+										This outreach is not linked to Job Tracker yet. If the recruiter responds positively, you can convert it directly to an active job application or interview.
 									</p>
 									<Button
 										onClick={handleConvertToJobTracker}
@@ -688,7 +688,7 @@ export default function JobOutreachDetailPage() {
 							<CardHeader className="p-4 pb-3">
 								<CardTitle className="text-sm font-bold uppercase tracking-wider text-muted-foreground flex items-center gap-2">
 									<Paperclip className="h-4 w-4 text-primary" />
-									Lampiran File ({outreach.attachments.length})
+									Attachments ({outreach.attachments.length})
 								</CardTitle>
 							</CardHeader>
 							<CardContent className="p-4 pt-0 space-y-2 text-xs">
@@ -721,14 +721,14 @@ export default function JobOutreachDetailPage() {
 						</CardHeader>
 						<CardContent className="p-4 pt-0 space-y-2.5 text-xs text-muted-foreground">
 							<div className="flex justify-between py-1 border-b border-border/40">
-								<span>Tanggal Dibuat:</span>
+								<span>Created Date:</span>
 								<span className="font-medium text-foreground">
 									{format(new Date(outreach.createdAt), "dd MMM yyyy")}
 								</span>
 							</div>
 
 							<div className="flex justify-between py-1 border-b border-border/40">
-								<span>Email Pertama Dikirim:</span>
+								<span>Initial Email Sent:</span>
 								<span className="font-medium text-foreground">
 									{outreach.sentAt ? format(new Date(outreach.sentAt), "dd MMM yyyy, HH:mm") : "-"}
 								</span>
@@ -747,9 +747,9 @@ export default function JobOutreachDetailPage() {
 							</div>
 
 							<div className="flex justify-between py-1">
-								<span>Balasan Terakhir:</span>
+								<span>Last Reply:</span>
 								<span className="font-medium text-emerald-500">
-									{outreach.lastRepliedAt ? format(new Date(outreach.lastRepliedAt), "dd MMM yyyy, HH:mm") : "Belum ada balasan"}
+									{outreach.lastRepliedAt ? format(new Date(outreach.lastRepliedAt), "dd MMM yyyy, HH:mm") : "No replies yet"}
 								</span>
 							</div>
 						</CardContent>
@@ -765,19 +765,19 @@ export default function JobOutreachDetailPage() {
 			>
 				<AlertDialogContent>
 					<AlertDialogHeader>
-						<AlertDialogTitle>Hapus Outreach Ini?</AlertDialogTitle>
+						<AlertDialogTitle>Delete This Outreach?</AlertDialogTitle>
 						<AlertDialogDescription>
-							Tindakan ini permanen dan akan menghapus seluruh rekaman draf email beserta balasan yang terkait.
+							This action is permanent and will delete the entire email draft along with all associated replies.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>
-						<AlertDialogCancel disabled={isDeleting}>Batal</AlertDialogCancel>
+						<AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
 						<AlertDialogAction
 							onClick={handleDelete}
 							disabled={isDeleting}
 							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
 						>
-							{isDeleting ? "Menghapus..." : "Hapus Outreach"}
+							{isDeleting ? "Deleting..." : "Delete Outreach"}
 						</AlertDialogAction>
 					</AlertDialogFooter>
 				</AlertDialogContent>

--- a/src/app/cms/job-outreaches/new/page.tsx
+++ b/src/app/cms/job-outreaches/new/page.tsx
@@ -139,10 +139,10 @@ export default function NewOutreachPage() {
 
 			const uploaded = await jobOutreachService.uploadAttachment(formData);
 			setAttachments((prev) => [...prev, uploaded]);
-			toast.success(`File "${file.name}" berhasil diunggah!`);
+			toast.success(`File "${file.name}" uploaded successfully!`);
 		} catch (err) {
 			console.error("Upload error:", err);
-			toast.error("Gagal mengunggah file attachment.");
+			toast.error("Failed to upload attachment file.");
 		} finally {
 			setIsUploading(false);
 			if (fileInputRef.current) fileInputRef.current.value = "";
@@ -155,7 +155,7 @@ export default function NewOutreachPage() {
 
 	const handleGenerateAi = async () => {
 		if (!companyName.trim() || !jobTitle.trim()) {
-			toast.error("Mohon isi Company Name dan Job Title terlebih dahulu.");
+			toast.error("Please fill in Company Name and Job Title first.");
 			return;
 		}
 
@@ -179,10 +179,10 @@ export default function NewOutreachPage() {
 
 			setSubject(result.subject);
 			setBody(result.body);
-			toast.success("Draf email berhasil dibuat oleh AI!");
+			toast.success("AI email draft generated successfully!");
 		} catch (err) {
 			console.error("AI Generation Error:", err);
-			toast.error("Gagal membuat draf AI. Silakan coba lagi.");
+			toast.error("Failed to generate AI draft. Please try again.");
 		} finally {
 			setIsGeneratingAi(false);
 		}
@@ -190,12 +190,12 @@ export default function NewOutreachPage() {
 
 	const handleSubmit = async (sendImmediately: boolean) => {
 		if (!companyName.trim() || !jobTitle.trim() || !contactName.trim() || !contactEmail.trim()) {
-			toast.error("Nama Perusahaan, Posisi, Nama Kontak, dan Email Kontak wajib diisi.");
+			toast.error("Company Name, Job Title, Contact Name, and Contact Email are required.");
 			return;
 		}
 
 		if (!subject.trim() || !body.trim()) {
-			toast.error("Subjek dan isi email wajib diisi.");
+			toast.error("Subject line and email body are required.");
 			return;
 		}
 
@@ -222,8 +222,8 @@ export default function NewOutreachPage() {
 
 			toast.success(
 				sendImmediately
-					? `Email berhasil dikirim ke ${contactEmail} via ${PUBLIC_SUPPORT_EMAIL}!`
-					: "Draf outreach berhasil disimpan.",
+					? `Email successfully sent to ${contactEmail} via ${PUBLIC_SUPPORT_EMAIL}!`
+					: "Outreach draft saved successfully.",
 			);
 
 			queryClient.invalidateQueries({ queryKey: ["jobOutreaches"] });
@@ -233,7 +233,7 @@ export default function NewOutreachPage() {
 
 		} catch (err) {
 			console.error("Submit outreach error:", err);
-			toast.error("Gagal menyimpan / mengirim outreach.");
+			toast.error("Failed to save or send outreach.");
 		} finally {
 			setIsSubmitting(false);
 		}
@@ -250,7 +250,7 @@ export default function NewOutreachPage() {
 					className="gap-2 -ml-2 text-muted-foreground hover:text-foreground text-xs font-medium"
 				>
 					<Link href="/cms/job-outreaches">
-						<ArrowLeft className="h-4 w-4" /> Kembali ke Job Outreaches
+						<ArrowLeft className="h-4 w-4" /> Back to Job Outreaches
 					</Link>
 				</Button>
 			</div>
@@ -263,7 +263,7 @@ export default function NewOutreachPage() {
 						New Job Outreach & Cold Pitch
 					</h1>
 					<p className="text-xs sm:text-sm text-muted-foreground mt-1">
-						Kirim pesan langsung ke recruiter / engineering lead via <strong className="text-foreground">{PUBLIC_SUPPORT_EMAIL}</strong>.
+						Send a direct message to recruiter / engineering lead via <strong className="text-foreground">{PUBLIC_SUPPORT_EMAIL}</strong>.
 					</p>
 				</div>
 
@@ -285,7 +285,7 @@ export default function NewOutreachPage() {
 					>
 						{isSubmitting ? (
 							<>
-								<Loader2 className="h-4 w-4 animate-spin" /> Mengirim...
+								<Loader2 className="h-4 w-4 animate-spin" /> Sending...
 							</>
 						) : (
 							<>
@@ -306,16 +306,16 @@ export default function NewOutreachPage() {
 						<CardHeader className="p-4 pb-3">
 							<CardTitle className="text-sm font-bold flex items-center gap-2 text-foreground">
 								<Briefcase className="h-4 w-4 text-primary" />
-								Hubungkan ke Job Tracker
+								Link to Job Tracker
 							</CardTitle>
 							<CardDescription className="text-xs">
-								Pilih lowongan yang sudah Anda catat di Job Tracker untuk auto-fill informasi.
+								Select an application tracked in Job Tracker to auto-fill information.
 							</CardDescription>
 						</CardHeader>
 						<CardContent className="p-4 pt-0">
 							<Select value={selectedJobAppId} onValueChange={handleSelectJobApp}>
 								<SelectTrigger className="w-full bg-background text-xs h-9">
-									<SelectValue placeholder="Pilih aplikasi..." />
+									<SelectValue placeholder="Select application..." />
 								</SelectTrigger>
 								<SelectContent>
 									<SelectItem value="none">-- Standalone Outreach --</SelectItem>
@@ -334,7 +334,7 @@ export default function NewOutreachPage() {
 						<CardHeader className="p-4 pb-3">
 							<CardTitle className="text-sm font-bold flex items-center gap-2 text-foreground">
 								<Building2 className="h-4 w-4 text-primary" />
-								Perusahaan & Posisi Target
+								Target Company & Role
 							</CardTitle>
 						</CardHeader>
 						<CardContent className="p-4 pt-0 space-y-3.5">
@@ -489,14 +489,14 @@ export default function NewOutreachPage() {
 							<div className="flex items-center justify-between">
 								<CardTitle className="text-sm font-bold flex items-center gap-2 text-foreground">
 									<Paperclip className="h-4 w-4 text-primary" />
-									Lampiran File (CV / Portfolio)
+									Attachments (CV / Portfolio)
 								</CardTitle>
 								<span className="text-[11px] text-muted-foreground">
-									{attachments.length} Terlampir
+									{attachments.length} Attached
 								</span>
 							</div>
 							<CardDescription className="text-xs">
-								Unggah file PDF CV, Portfolio, atau dokumen pendukung yang akan otomatis dikirimkan sebagai attachment di Resend.
+								Upload PDF CV, Portfolio, or supporting documents to automatically attach and send via Resend.
 							</CardDescription>
 						</CardHeader>
 						<CardContent className="p-4 pt-0 space-y-3">
@@ -520,17 +520,17 @@ export default function NewOutreachPage() {
 								{isUploading ? (
 									<>
 										<Loader2 className="h-6 w-6 text-primary animate-spin" />
-										<span className="text-xs font-medium">Mengunggah file ke Vercel Blob...</span>
+										<span className="text-xs font-medium">Uploading file to Vercel Blob...</span>
 									</>
 								) : (
 									<>
 										<UploadCloud className="h-6 w-6 text-muted-foreground" />
 										<div className="space-y-0.5">
 											<div className="text-xs font-semibold text-foreground">
-												Klik untuk Upload File (PDF, DOCX, ZIP)
+												Click to Upload File (PDF, DOCX, ZIP)
 											</div>
 											<div className="text-[11px] text-muted-foreground">
-												Maksimal 10MB per file
+												Maximum 10MB per file
 											</div>
 										</div>
 									</>
@@ -604,7 +604,7 @@ export default function NewOutreachPage() {
 							</div>
 
 							<Input
-								placeholder="Optional: Tambahkan instruksi spesifik (misal: 'Sebutkan bahwa saya terbiasa membangun AI Agent Next.js')..."
+								placeholder="Optional: Add specific instructions (e.g. 'Mention my experience building AI Agents with Next.js')..."
 								className="bg-background/90 text-xs h-9"
 								value={customPrompt}
 								onChange={(e) => setCustomPrompt(e.target.value)}
@@ -646,7 +646,7 @@ export default function NewOutreachPage() {
 								<Textarea
 									id="body"
 									rows={14}
-									placeholder="Tulis pesan Anda di sini atau gunakan AI Auto-Draft di atas..."
+									placeholder="Write your message here or use AI Auto-Draft above..."
 									className="font-sans text-sm leading-relaxed"
 									value={body}
 									onChange={(e) => setBody(e.target.value)}
@@ -655,11 +655,11 @@ export default function NewOutreachPage() {
 
 							<div className="space-y-1.5">
 								<Label htmlFor="notes" className="text-xs text-muted-foreground">
-									Private Internal Notes (Hanya terlihat di dashboard Anda)
+									Private Internal Notes (Only visible in your dashboard)
 								</Label>
 								<Input
 									id="notes"
-									placeholder="e.g. Di-refer oleh John Doe / Dilamar setelah melihat tweet founder..."
+									placeholder="e.g. Referred by John Doe / Applied after seeing founder's tweet..."
 									className="text-xs h-8"
 									value={notes}
 									onChange={(e) => setNotes(e.target.value)}
@@ -671,7 +671,7 @@ export default function NewOutreachPage() {
 							<div className="flex flex-col sm:flex-row items-center justify-between gap-3 pt-2">
 								<div className="text-xs text-muted-foreground flex items-center gap-1.5">
 									<Check className="h-3.5 w-3.5 text-emerald-500" />
-									<span>Balasan dari recruiter otomatis masuk ke timeline CMS ini.</span>
+									<span>Replies from recruiter will automatically sync to this CMS timeline.</span>
 								</div>
 
 								<div className="flex items-center gap-2 w-full sm:w-auto">
@@ -692,7 +692,7 @@ export default function NewOutreachPage() {
 									>
 										{isSubmitting ? (
 											<>
-												<Loader2 className="h-4 w-4 animate-spin" /> Mengirim...
+												<Loader2 className="h-4 w-4 animate-spin" /> Sending...
 											</>
 										) : (
 											<>

--- a/src/app/cms/job-outreaches/page.tsx
+++ b/src/app/cms/job-outreaches/page.tsx
@@ -170,13 +170,13 @@ export default function JobOutreachesPage() {
 		setIsDeleting(true);
 		try {
 			await jobOutreachService.delete(deleteTargetId);
-			toast.success("Outreach berhasil dihapus.");
+			toast.success("Outreach successfully deleted.");
 			setDeleteTargetId(null);
 			queryClient.invalidateQueries({ queryKey: ["jobOutreaches"] });
 			queryClient.invalidateQueries({ queryKey: ["jobOutreachesAnalytics"] });
 		} catch (err) {
 			console.error("Delete outreach error:", err);
-			toast.error("Gagal menghapus outreach.");
+			toast.error("Failed to delete outreach.");
 		} finally {
 			setIsDeleting(false);
 		}
@@ -185,18 +185,18 @@ export default function JobOutreachesPage() {
 	const handleSendDraft = async (id: string, contactEmail: string) => {
 		try {
 			await jobOutreachService.sendEmail(id);
-			toast.success(`Email berhasil dikirim ke ${contactEmail} via ${PUBLIC_SUPPORT_EMAIL}!`);
+			toast.success(`Email successfully sent to ${contactEmail}!`);
 			queryClient.invalidateQueries({ queryKey: ["jobOutreaches"] });
 			queryClient.invalidateQueries({ queryKey: ["jobOutreachesAnalytics"] });
 		} catch (err) {
-			console.error("Send draft error:", err);
-			toast.error("Gagal mengirim email draf.");
+			console.error("Send email error:", err);
+			toast.error("Failed to send email.");
 		}
 	};
 
 	return (
 		<div className="space-y-6 pb-12">
-			{/* Header */}
+			{/* Page Header */}
 			<div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
 				<div>
 					<h1 className="text-2xl sm:text-3xl font-bold tracking-tight flex items-center gap-2">
@@ -204,7 +204,7 @@ export default function JobOutreachesPage() {
 						Job Outreaches & Cold Emails
 					</h1>
 					<p className="text-sm text-muted-foreground mt-1">
-						Kelola cold outreach, direct application via email, dan pantau balasan dari recruiter secara terintegrasi melalui{" "}
+						Manage cold outreach, direct email applications, and track recruiter replies seamlessly through{" "}
 						<strong className="text-foreground">{PUBLIC_SUPPORT_EMAIL}</strong>.
 					</p>
 				</div>
@@ -325,7 +325,7 @@ export default function JobOutreachesPage() {
 					<div className="relative flex-1 sm:w-64">
 						<Search className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
 						<Input
-							placeholder="Cari perusahaan, posisi, nama kontak..."
+							placeholder="Search company, job title, contact name..."
 							className="pl-9 h-9 text-xs"
 							value={searchQuery}
 							onChange={(e) => setSearchQuery(e.target.value)}
@@ -363,13 +363,13 @@ export default function JobOutreachesPage() {
 					<div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-primary/10 text-primary mb-4">
 						<SendHorizontal className="h-7 w-7" />
 					</div>
-					<h3 className="text-lg font-semibold mb-1">Belum ada Job Outreach</h3>
+					<h3 className="text-lg font-semibold mb-1">No Job Outreaches Yet</h3>
 					<p className="text-sm text-muted-foreground max-w-md mx-auto mb-5">
-						Mulai inisiasi cold email atau kirim direct job application ke recruiter target Anda menggunakan AI generator.
+						Start initiating cold emails or send direct job applications to your target recruiters using the AI generator.
 					</p>
 					<Button asChild className="gap-2 font-medium">
 						<Link href="/cms/job-outreaches/new">
-							<Plus className="h-4 w-4" /> Mulai Outreach Pertama
+							<Plus className="h-4 w-4" /> Start First Outreach
 						</Link>
 					</Button>
 				</Card>
@@ -433,20 +433,20 @@ export default function JobOutreachesPage() {
 											<DropdownMenuContent align="end">
 												<DropdownMenuItem asChild>
 													<Link href={`/cms/job-outreaches/${item.id}`}>
-														<Eye className="h-4 w-4 mr-2" /> Buka Thread Percakapan
+														<Eye className="h-4 w-4 mr-2" /> Open Conversation Thread
 													</Link>
 												</DropdownMenuItem>
 												{item.status === "draft" && (
 													<DropdownMenuItem
 														onClick={() => handleSendDraft(item.id, item.contactEmail)}
 													>
-														<Send className="h-4 w-4 mr-2 text-primary" /> Kirim Sekarang (Resend)
+														<Send className="h-4 w-4 mr-2 text-primary" /> Send Now (Resend)
 													</DropdownMenuItem>
 												)}
 												{item.jobApplicationId && (
 													<DropdownMenuItem asChild>
 														<Link href={`/cms/job-tracker/${item.jobApplicationId}`}>
-															<Briefcase className="h-4 w-4 mr-2" /> Lihat di Job Tracker
+															<Briefcase className="h-4 w-4 mr-2" /> View in Job Tracker
 														</Link>
 													</DropdownMenuItem>
 												)}
@@ -455,7 +455,7 @@ export default function JobOutreachesPage() {
 													onClick={() => setDeleteTargetId(item.id)}
 													className="text-destructive focus:text-destructive"
 												>
-													<Trash2 className="h-4 w-4 mr-2" /> Hapus Outreach
+													<Trash2 className="h-4 w-4 mr-2" /> Delete Outreach
 												</DropdownMenuItem>
 											</DropdownMenuContent>
 										</DropdownMenu>
@@ -526,10 +526,10 @@ export default function JobOutreachesPage() {
 											<Calendar className="h-3 w-3" />
 											{item.sentAt ? (
 												<span>
-													Dikirim {formatDistanceToNow(new Date(item.sentAt), { addSuffix: true })}
+													Sent {formatDistanceToNow(new Date(item.sentAt), { addSuffix: true })}
 												</span>
 											) : (
-												<span>Draf dibuat {format(new Date(item.createdAt), "dd MMM yyyy")}</span>
+												<span>Draft created {format(new Date(item.createdAt), "dd MMM yyyy")}</span>
 											)}
 										</div>
 
@@ -554,11 +554,11 @@ export default function JobOutreachesPage() {
 											<Link href={`/cms/job-outreaches/${item.id}`}>
 												{item.status === "replied" ? (
 													<>
-														<MessageSquare className="h-3.5 w-3.5" /> Lihat Balasan Recruiter
+														<MessageSquare className="h-3.5 w-3.5" /> View Recruiter Reply
 													</>
 												) : (
 													<>
-														<Eye className="h-3.5 w-3.5" /> Detail & Follow-up
+														<Eye className="h-3.5 w-3.5" /> Details & Follow-up
 													</>
 												)}
 											</Link>
@@ -578,19 +578,19 @@ export default function JobOutreachesPage() {
 			>
 				<AlertDialogContent>
 					<AlertDialogHeader>
-						<AlertDialogTitle>Hapus Outreach Ini?</AlertDialogTitle>
+						<AlertDialogTitle>Delete This Outreach?</AlertDialogTitle>
 						<AlertDialogDescription>
-							Tindakan ini akan menghapus data outreach serta riwayat percakapan thread email yang terkait.
+							This action will delete the outreach data along with all associated email thread conversations.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>
-						<AlertDialogCancel disabled={isDeleting}>Batal</AlertDialogCancel>
+						<AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
 						<AlertDialogAction
 							onClick={handleDelete}
 							disabled={isDeleting}
 							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
 						>
-							{isDeleting ? "Menghapus..." : "Hapus Outreach"}
+							{isDeleting ? "Deleting..." : "Delete Outreach"}
 						</AlertDialogAction>
 					</AlertDialogFooter>
 				</AlertDialogContent>

--- a/src/app/cms/services/[id]/page.tsx
+++ b/src/app/cms/services/[id]/page.tsx
@@ -190,14 +190,14 @@ export default function ServiceRequestDetailPage() {
 				originalMessageSnippet: request.projectDetails,
 			});
 
-			toast.success("Balasan email berhasil dikirim ke klien!");
+			toast.success("Email reply successfully sent to client!");
 			setReplyMessage("");
 			refetchThread();
 			refetchRequest();
 			queryClient.invalidateQueries({ queryKey: ["serviceRequests"] });
 		} catch (error) {
 			console.error("Error sending reply:", error);
-			const msg = error instanceof Error ? error.message : "Gagal mengirim balasan email";
+			const msg = error instanceof Error ? error.message : "Failed to send email reply";
 			toast.error(msg);
 		} finally {
 			setIsSendingReply(false);
@@ -222,12 +222,12 @@ export default function ServiceRequestDetailPage() {
 		setIsDeleting(true);
 		try {
 			await serviceRequestService.delete(request.id);
-			toast.success("Service request berhasil dihapus");
+			toast.success("Service request successfully deleted");
 			queryClient.invalidateQueries({ queryKey: ["serviceRequests"] });
 			router.push("/cms/services");
 		} catch (error) {
 			console.error("Error deleting service request:", error);
-			toast.error("Gagal menghapus service request");
+			toast.error("Failed to delete service request");
 		} finally {
 			setIsDeleting(false);
 		}
@@ -323,10 +323,10 @@ export default function ServiceRequestDetailPage() {
 				<Inbox className="w-12 h-12 text-muted-foreground mx-auto" />
 				<h2 className="text-xl font-semibold">Service Request Not Found</h2>
 				<p className="text-sm text-muted-foreground">
-					Permintaan layanan yang Anda cari tidak ditemukan atau telah dihapus.
+					The service request you are looking for was not found or has been deleted.
 				</p>
 				<Button asChild variant="outline">
-					<Link href="/cms/services">Kembali ke Daftar</Link>
+					<Link href="/cms/services">Back to List</Link>
 				</Button>
 			</div>
 		);
@@ -353,7 +353,7 @@ export default function ServiceRequestDetailPage() {
 				<Button asChild variant="ghost" size="sm" className="gap-2 -ml-2 text-muted-foreground hover:text-foreground">
 					<Link href="/cms/services">
 						<ArrowLeft className="w-4 h-4" />
-						<span>Kembali ke Service Requests</span>
+						<span>Back to Service Requests</span>
 					</Link>
 				</Button>
 
@@ -408,11 +408,11 @@ export default function ServiceRequestDetailPage() {
 						{getStatusBadge(request.status)}
 					</div>
 					<p className="text-xs sm:text-sm text-muted-foreground flex flex-wrap items-center gap-1.5 sm:gap-2">
-						<span>Permintaan layanan</span>
+						<span>Service Request</span>
 						<span>•</span>
 						<span className="font-medium text-foreground">{serviceConfig.label}</span>
 						<span>•</span>
-						<span>Diajukan {format(new Date(request.createdAt), "dd MMM yyyy, HH:mm")}</span>
+						<span>Submitted {format(new Date(request.createdAt), "dd MMM yyyy, HH:mm")}</span>
 					</p>
 				</div>
 			</div>
@@ -427,10 +427,10 @@ export default function ServiceRequestDetailPage() {
 							<div className="flex items-center justify-between">
 								<CardTitle className="text-sm font-semibold flex items-center gap-2">
 									<Briefcase className="w-4 h-4 text-primary" />
-									<span>Rincian Kebutuhan Proyek</span>
+									<span>Project Requirements</span>
 								</CardTitle>
 								<Badge variant="outline" className="text-[10px]">
-									Inquiry Awal
+									Original Inquiry
 								</Badge>
 							</div>
 						</CardHeader>
@@ -447,7 +447,7 @@ export default function ServiceRequestDetailPage() {
 							<div className="flex items-center justify-between">
 								<CardTitle className="text-sm font-semibold flex items-center gap-2">
 									<MessageSquare className="w-4 h-4 text-primary" />
-									<span>Riwayat Percakapan ({threadMessages.length})</span>
+									<span>Conversation Thread ({threadMessages.length})</span>
 								</CardTitle>
 								<Button
 									variant="ghost"
@@ -463,7 +463,7 @@ export default function ServiceRequestDetailPage() {
 						<CardContent className="p-4 sm:p-6 pt-0 space-y-4">
 							{threadMessages.length === 0 ? (
 								<div className="text-center py-8 text-muted-foreground text-xs bg-muted/10 rounded-xl border border-dashed border-border/60">
-									Belum ada balasan email terkirim. Tulis pesan di bawah untuk memulai komunikasi.
+									No email replies sent yet. Write a message below to start communicating.
 								</div>
 							) : (
 								<div className="space-y-3">
@@ -506,15 +506,15 @@ export default function ServiceRequestDetailPage() {
 								<div className="flex flex-wrap justify-between items-center gap-1">
 									<label className="text-xs font-semibold text-foreground flex items-center gap-1.5">
 										<Mail className="h-4 w-4 text-primary" />
-										<span>Kirim Balasan Email ke Klien</span>
+										<span>Send Email Reply to Client</span>
 									</label>
 									<span className="text-[11px] text-muted-foreground">
-										Pengirim: <strong className="text-primary font-medium">{PUBLIC_SUPPORT_EMAIL}</strong>
+										Sender: <strong className="text-primary font-medium">{PUBLIC_SUPPORT_EMAIL}</strong>
 									</span>
 								</div>
 
 								<Textarea
-									placeholder={`Tulis estimasi, penawaran harga, atau pertanyaan detail untuk ${request.name}... (Akan langsung dikirimkan ke ${request.email})`}
+									placeholder={`Write an estimate, quote, or detailed questions for ${request.name}... (Will be sent directly to ${request.email})`}
 									value={replyMessage}
 									onChange={(e) => setReplyMessage(e.target.value)}
 									rows={5}
@@ -523,7 +523,7 @@ export default function ServiceRequestDetailPage() {
 
 								<div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2.5">
 									<span className="text-[11px] text-muted-foreground">
-										Klien dapat langsung membalas email Anda via inbox email mereka.
+										Client can reply directly to your email from their inbox.
 									</span>
 									<Button
 										size="sm"
@@ -534,12 +534,12 @@ export default function ServiceRequestDetailPage() {
 										{isSendingReply ? (
 											<>
 												<Loader2 className="h-3.5 w-3.5 animate-spin" />
-												<span>Mengirim...</span>
+												<span>Sending...</span>
 											</>
 										) : (
 											<>
 												<Send className="h-3.5 w-3.5" />
-												<span>Kirim Balasan Email</span>
+												<span>Send Email Reply</span>
 											</>
 										)}
 									</Button>
@@ -556,7 +556,7 @@ export default function ServiceRequestDetailPage() {
 						<CardHeader className="p-4 sm:p-5 pb-3">
 							<CardTitle className="text-xs font-semibold text-muted-foreground uppercase tracking-wider flex items-center gap-1.5">
 								<User className="h-3.5 w-3.5 text-primary" />
-								<span>Informasi Klien</span>
+								<span>Client Information</span>
 							</CardTitle>
 						</CardHeader>
 						<CardContent className="p-4 sm:p-5 pt-0 space-y-4">
@@ -602,7 +602,7 @@ export default function ServiceRequestDetailPage() {
 
 								{request.company && (
 									<div>
-										<div className="text-muted-foreground mb-0.5">Perusahaan / Brand:</div>
+										<div className="text-muted-foreground mb-0.5">Company / Brand:</div>
 										<div className="flex items-center gap-1.5 font-medium text-foreground bg-muted/30 p-2 rounded-lg border border-border/40 truncate">
 											<Building2 className="h-3.5 w-3.5 text-muted-foreground/70 shrink-0" />
 											<span className="truncate">{request.company}</span>
@@ -618,12 +618,12 @@ export default function ServiceRequestDetailPage() {
 						<CardHeader className="p-4 sm:p-5 pb-3">
 							<CardTitle className="text-xs font-semibold text-muted-foreground uppercase tracking-wider flex items-center gap-1.5">
 								<Briefcase className="h-3.5 w-3.5 text-primary" />
-								<span>Parameter Layanan</span>
+								<span>Service Parameters</span>
 							</CardTitle>
 						</CardHeader>
 						<CardContent className="p-4 sm:p-5 pt-0 space-y-3 text-xs">
 							<div className="flex justify-between items-center py-1 border-b border-border/40 gap-2">
-								<span className="text-muted-foreground shrink-0">Tipe Layanan:</span>
+								<span className="text-muted-foreground shrink-0">Service Type:</span>
 								<Badge variant="outline" className={cn("gap-1.5 text-xs font-medium truncate", serviceConfig.className)}>
 									<ServiceIcon className="h-3 w-3 shrink-0" />
 									<span className="truncate max-w-[140px] sm:max-w-none">{serviceConfig.label}</span>
@@ -631,7 +631,7 @@ export default function ServiceRequestDetailPage() {
 							</div>
 
 							<div className="flex justify-between items-center py-1 border-b border-border/40 gap-2">
-								<span className="text-muted-foreground shrink-0">Estimasi Budget:</span>
+								<span className="text-muted-foreground shrink-0">Estimated Budget:</span>
 								<div className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-md bg-muted/40 border border-border/50 font-semibold tabular-nums text-foreground">
 									<DollarSign className="h-3.5 w-3.5 text-emerald-500 shrink-0 -mr-0.5" />
 									<span>{getBudgetLabel(request.budget)}</span>
@@ -639,7 +639,7 @@ export default function ServiceRequestDetailPage() {
 							</div>
 
 							<div className="flex justify-between items-center py-1 gap-2">
-								<span className="text-muted-foreground shrink-0">Target Waktu:</span>
+								<span className="text-muted-foreground shrink-0">Timeframe:</span>
 								<Badge variant="outline" className={cn("gap-1 text-xs font-medium truncate", timeframeConfig.className)}>
 									<TimeframeIcon className="h-3 w-3 shrink-0" />
 									<span className="truncate max-w-[140px] sm:max-w-none">{timeframeConfig.label}</span>
@@ -656,7 +656,7 @@ export default function ServiceRequestDetailPage() {
 								<span className="font-mono text-foreground/80 truncate max-w-[160px]">{request.id}</span>
 							</div>
 							<div className="flex justify-between gap-2">
-								<span>Tanggal Pengajuan:</span>
+								<span>Submitted Date:</span>
 								<span className="text-foreground/80 whitespace-nowrap">
 									{format(new Date(request.createdAt), "dd MMM yyyy HH:mm")}
 								</span>
@@ -670,15 +670,15 @@ export default function ServiceRequestDetailPage() {
 			<AlertDialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
 				<AlertDialogContent>
 					<AlertDialogHeader>
-						<AlertDialogTitle>Hapus Service Request?</AlertDialogTitle>
+						<AlertDialogTitle>Delete Service Request?</AlertDialogTitle>
 						<AlertDialogDescription>
-							Tindakan ini tidak dapat dibatalkan. Permintaan layanan dari{" "}
-							<strong className="text-foreground">{request.name}</strong> ({request.email}) beserta
-							seluruh riwayat percakapan email akan dihapus secara permanen.
+							This action cannot be undone. The service request from{" "}
+							<strong className="text-foreground">{request.name}</strong> ({request.email}) and its
+							entire email conversation history will be permanently deleted.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>
-						<AlertDialogCancel disabled={isDeleting}>Batal</AlertDialogCancel>
+						<AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
 						<AlertDialogAction
 							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
 							onClick={handleDelete}
@@ -687,10 +687,10 @@ export default function ServiceRequestDetailPage() {
 							{isDeleting ? (
 								<>
 									<Loader2 className="h-4 w-4 mr-2 animate-spin" />
-									Menghapus...
+									Deleting...
 								</>
 							) : (
-								"Hapus Permanen"
+								"Delete Permanently"
 							)}
 						</AlertDialogAction>
 					</AlertDialogFooter>

--- a/src/app/cms/services/page.tsx
+++ b/src/app/cms/services/page.tsx
@@ -205,12 +205,12 @@ export default function CmsServicesPage() {
 		setIsDeleting(true);
 		try {
 			await serviceRequestService.delete(requestToDelete.id);
-			toast.success("Service request berhasil dihapus");
+			toast.success("Service request successfully deleted");
 			setRequestToDelete(null);
 			refetch();
 		} catch (error) {
 			console.error("Error deleting service request:", error);
-			toast.error("Gagal menghapus service request");
+			toast.error("Failed to delete service request");
 		} finally {
 			setIsDeleting(false);
 		}
@@ -675,17 +675,16 @@ export default function CmsServicesPage() {
 			>
 				<AlertDialogContent>
 					<AlertDialogHeader>
-						<AlertDialogTitle>Hapus Service Request?</AlertDialogTitle>
+						<AlertDialogTitle>Delete Service Request?</AlertDialogTitle>
 						<AlertDialogDescription>
-							Tindakan ini tidak dapat dibatalkan. Permintaan layanan dari{" "}
+							This action cannot be undone. The service request from{" "}
 							<strong className="text-foreground">{requestToDelete?.name}</strong> (
-							{requestToDelete?.email}) untuk layanan{" "}
-							<strong className="text-foreground">{requestToDelete?.serviceType}</strong>{" "}
-							beserta seluruh riwayat balasan email akan dihapus secara permanen.
+							{requestToDelete?.email}) for service{" "}
+							<strong className="text-foreground">{requestToDelete?.serviceType}</strong> and all related email thread history will be permanently deleted.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>
-						<AlertDialogCancel disabled={isDeleting}>Batal</AlertDialogCancel>
+						<AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
 						<AlertDialogAction
 							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
 							onClick={handleDeleteRequest}
@@ -694,10 +693,10 @@ export default function CmsServicesPage() {
 							{isDeleting ? (
 								<>
 									<Loader2 className="h-4 w-4 mr-2 animate-spin" />
-									Menghapus...
+									Deleting...
 								</>
 							) : (
-								"Hapus"
+								"Delete"
 							)}
 						</AlertDialogAction>
 					</AlertDialogFooter>

--- a/src/components/emails/admin-direct-email-alert.tsx
+++ b/src/components/emails/admin-direct-email-alert.tsx
@@ -33,7 +33,7 @@ export const AdminDirectEmailAlertEmail = ({
 	toAddress = PUBLIC_SUPPORT_EMAIL,
 	receivedAt = new Date().toLocaleString("id-ID", { timeZone: "Asia/Jakarta" }),
 }: AdminDirectEmailAlertProps) => {
-	const previewText = `[New Direct Email] ${subject} dari ${clientName}`;
+	const previewText = `[New Direct Email] ${subject} from ${clientName}`;
 	const cmsUrl = `https://wismannur.pro/cms/contacts/${inquiryId}`;
 
 	return (
@@ -43,42 +43,42 @@ export const AdminDirectEmailAlertEmail = ({
 			<Body style={main}>
 				<Container style={container}>
 					<Section style={headerSection}>
-						<Heading style={headerTitle}>✉️ Direct Email Masuk</Heading>
+						<Heading style={headerTitle}>✉️ Direct Inbound Email</Heading>
 						<Text style={headerSubtitle}>
-							Email langsung diterima di <strong>{toAddress}</strong> via Resend Inbound
+							Direct email received at <strong>{toAddress}</strong> via Resend Inbound
 						</Text>
 					</Section>
 
 					<Section style={card}>
-						<Text style={label}>Dari Pengirim</Text>
+						<Text style={label}>From Sender</Text>
 						<Text style={value}>
 							<strong>{clientName}</strong> ({clientEmail})
 						</Text>
 
-						<Text style={label}>Subjek</Text>
+						<Text style={label}>Subject</Text>
 						<Text style={value}>{subject}</Text>
 
-						<Text style={label}>Ditujukan Ke</Text>
+						<Text style={label}>Delivered To</Text>
 						<Text style={value}>{toAddress}</Text>
 
-						<Text style={label}>ID Kontak CMS</Text>
+						<Text style={label}>CMS Contact ID</Text>
 						<Text style={value}>#{inquiryId}</Text>
 
-						<Text style={label}>Waktu Terima (WIB)</Text>
+						<Text style={label}>Received At (WIB)</Text>
 						<Text style={value}>{receivedAt}</Text>
 
 						<Hr style={divider} />
 
-						<Text style={label}>Isi Pesan</Text>
+						<Text style={label}>Message Content</Text>
 						<Text style={messageBox}>{message}</Text>
 					</Section>
 
 					<Section style={footerSection}>
 						<Link href={cmsUrl} style={buttonStyle}>
-							Buka Kontak di CMS
+							Open Contact in CMS
 						</Link>
 						<Text style={footerText}>
-							Pesan ini otomatis dicatat sebagai kontak baru di inbox CMS Anda. Anda dapat membalas via CMS atau langsung me-reply email notifikasi ini.
+							This message is automatically recorded as a new contact in your CMS inbox. You can reply via CMS or directly reply to this notification email.
 						</Text>
 					</Section>
 				</Container>

--- a/src/components/emails/admin-inbound-alert.tsx
+++ b/src/components/emails/admin-inbound-alert.tsx
@@ -31,7 +31,7 @@ export const AdminInboundAlertEmail = ({
 	message,
 	receivedAt = new Date().toLocaleString("id-ID", { timeZone: "Asia/Jakarta" }),
 }: AdminInboundAlertProps) => {
-	const previewText = `[Inbound Reply] ${clientName} membalas: ${subject}`;
+	const previewText = `[Inbound Reply] ${clientName} replied: ${subject}`;
 	const cmsUrl =
 		inquiryType === "job_outreach"
 			? `https://wismannur.pro/cms/job-outreaches/${inquiryId}`
@@ -49,37 +49,37 @@ export const AdminInboundAlertEmail = ({
 			<Body style={main}>
 				<Container style={container}>
 					<Section style={headerSection}>
-						<Heading style={headerTitle}>💬 Balasan Baru dari Klien</Heading>
-						<Text style={headerSubtitle}>Klien membalas email percakapan via Resend Inbound</Text>
+						<Heading style={headerTitle}>💬 New Inbound Reply</Heading>
+						<Text style={headerSubtitle}>Client replied to email thread via Resend Inbound</Text>
 					</Section>
 
 					<Section style={card}>
-						<Text style={label}>Dari Klien</Text>
+						<Text style={label}>From Client</Text>
 						<Text style={value}>
 							<strong>{clientName}</strong> ({clientEmail})
 						</Text>
 
-						<Text style={label}>Subjek</Text>
+						<Text style={label}>Subject</Text>
 						<Text style={value}>{subject}</Text>
 
-						<Text style={label}>ID Tiket / Ref</Text>
+						<Text style={label}>Ticket ID / Ref</Text>
 						<Text style={value}>#{inquiryId}</Text>
 
-						<Text style={label}>Waktu Terima (WIB)</Text>
+						<Text style={label}>Received At (WIB)</Text>
 						<Text style={value}>{receivedAt}</Text>
 
 						<Hr style={divider} />
 
-						<Text style={label}>Isi Balasan Klien</Text>
+						<Text style={label}>Client Reply Message</Text>
 						<Text style={messageBox}>{message}</Text>
 					</Section>
 
 					<Section style={footerSection}>
 						<Link href={cmsUrl} style={buttonStyle}>
-							Buka Thread di CMS
+							Open Thread in CMS
 						</Link>
 						<Text style={footerText}>
-							Pesan ini otomatis tercatat di timeline percakapan CMS Anda.
+							This message is automatically recorded in your CMS conversation thread.
 						</Text>
 					</Section>
 				</Container>

--- a/src/components/emails/admin-reply-to-client.tsx
+++ b/src/components/emails/admin-reply-to-client.tsx
@@ -36,13 +36,13 @@ export const AdminReplyToClientEmail = ({
 			<Body style={main}>
 				<Container style={container}>
 					<Section style={bodySection}>
-						<Text style={greeting}>Halo {clientName},</Text>
+						<Text style={greeting}>Hi {clientName},</Text>
 						<Text style={replyMessageBox}>{replyMessage}</Text>
 					</Section>
 
 					{originalMessageSnippet && (
 						<Section style={quoteCard}>
-							<Text style={quoteLabel}>Menanggapi pesan sebelumnya ({originalSubject}):</Text>
+							<Text style={quoteLabel}>In response to previous message ({originalSubject}):</Text>
 							<Text style={quoteText}>{originalMessageSnippet}</Text>
 						</Section>
 					)}
@@ -71,7 +71,7 @@ export const AdminReplyToClientEmail = ({
 
 					<Section style={footerSection}>
 						<Text style={footerText}>
-							Anda dapat langsung membalas (reply) email ini jika ada pertanyaan atau diskusi lanjutan.
+							You can reply directly to this email for any questions or follow-up discussion.
 						</Text>
 						{inquiryId && (
 							<Text style={refFooterText}>

--- a/src/components/emails/client-contact-auto-reply.tsx
+++ b/src/components/emails/client-contact-auto-reply.tsx
@@ -35,29 +35,29 @@ export const ClientContactAutoReplyEmail = ({
 				<Container style={container}>
 					<Section style={headerSection}>
 						<Text style={brand}>Wisman Nur</Text>
-						<Heading style={headerTitle}>Pesan Anda telah diterima ✨</Heading>
-						<Text style={headerSubtitle}>Terima kasih telah menghubungi saya.</Text>
+						<Heading style={headerTitle}>Your message has been received ✨</Heading>
+						<Text style={headerSubtitle}>Thank you for reaching out.</Text>
 					</Section>
 
 					<Section style={bodySection}>
-						<Text style={greeting}>Halo {name},</Text>
+						<Text style={greeting}>Hi {name},</Text>
 						<Text style={paragraph}>
-							Terima kasih telah mengirimkan pesan melalui situs{" "}
+							Thank you for getting in touch through{" "}
 							<Link href="https://wismannur.pro" style={linkStyle}>
 								wismannur.pro
 							</Link>
-							. Pesan Anda sudah masuk ke sistem dan akan saya pelajari.
+							. Your message has been received and I will review it shortly.
 						</Text>
 						<Text style={paragraph}>
-							Saya akan membalas pesan Anda sesegera mungkin, maksimal dalam waktu{" "}
-							<strong>1x24 jam</strong> kerja.
+							I will respond to your message as soon as possible, usually within{" "}
+							<strong>24 business hours</strong>.
 						</Text>
 					</Section>
 
 					<Section style={summaryCard}>
-						<Text style={summaryLabel}>Ringkasan Pesan Anda:</Text>
+						<Text style={summaryLabel}>Message Summary:</Text>
 						<Text style={summarySubject}>
-							<strong>Subjek:</strong> {subject}
+							<strong>Subject:</strong> {subject}
 						</Text>
 						<Text style={summaryMessage}>{message}</Text>
 					</Section>
@@ -86,8 +86,8 @@ export const ClientContactAutoReplyEmail = ({
 
 					<Section style={footerSection}>
 						<Text style={footerText}>
-							Email ini dikirim secara otomatis sebagai konfirmasi bahwa pesan Anda telah berhasil
-							diterima.
+							This email was sent automatically to confirm that your message was successfully
+							received.
 						</Text>
 						{refId && (
 							<Text style={refFooterText}>

--- a/src/components/emails/client-hire-request-auto-reply.tsx
+++ b/src/components/emails/client-hire-request-auto-reply.tsx
@@ -31,7 +31,7 @@ export const ClientHireRequestAutoReplyEmail = ({
 	message,
 	refId,
 }: ClientHireRequestAutoReplyProps) => {
-	const previewText = `Terima kasih atas penawaran posisi ${roleTitle} di ${company}, ${name}! - Wisman Nur`;
+	const previewText = `Thank you for the opportunity for the ${roleTitle} role at ${company}, ${name}! - Wisman Nur`;
 
 	const formatEmployment = (type: string) => {
 		switch (type) {
@@ -67,39 +67,37 @@ export const ClientHireRequestAutoReplyEmail = ({
 				<Container style={container}>
 					<Section style={headerSection}>
 						<Text style={brand}>Wisman Nur · Career Opportunity</Text>
-						<Heading style={headerTitle}>Pesan Penawaran / Lowongan Diterima 🎯</Heading>
-						<Text style={headerSubtitle}>Terima kasih atas ketertarikan Anda untuk bekerja sama.</Text>
+						<Heading style={headerTitle}>Opportunity / Hire Request Received 🎯</Heading>
+						<Text style={headerSubtitle}>Thank you for your interest in working together.</Text>
 					</Section>
 
 					<Section style={bodySection}>
-						<Text style={greeting}>Halo {name},</Text>
+						<Text style={greeting}>Hi {name},</Text>
 						<Text style={paragraph}>
-							Terima kasih telah menghubungi saya mengenai peluang posisi{" "}
-							<strong>{roleTitle}</strong> di <strong>{company}</strong> via{" "}
+							Thank you for reaching out regarding the opportunity for{" "}
+							<strong>{roleTitle}</strong> at <strong>{company}</strong> via{" "}
 							<Link href="https://wismannur.pro/hire-me" style={linkStyle}>
 								wismannur.pro/hire-me
 							</Link>
 							.
 						</Text>
 						<Text style={paragraph}>
-							Saya sangat mengapresiasi penawaran ini. Saya akan mempelajari profil perusahaan,
-							detail peran, dan kesesuaian teknis secara mendalam, lalu akan segera membalas email Anda
-							maksimal dalam waktu <strong>1x24 jam</strong> kerja.
+							I appreciate this opportunity. I will review the company profile, role details, and technical fit thoroughly, and get back to you within <strong>24 business hours</strong>.
 						</Text>
 					</Section>
 
 					<Section style={summaryCard}>
-						<Text style={summaryLabel}>Ringkasan Informasi:</Text>
+						<Text style={summaryLabel}>Summary of Details:</Text>
 						<Text style={summaryItem}>
-							<strong>Perusahaan:</strong> {company}
+							<strong>Company:</strong> {company}
 						</Text>
 						<Text style={summaryItem}>
-							<strong>Posisi:</strong> {roleTitle}
+							<strong>Position:</strong> {roleTitle}
 						</Text>
 						<Text style={summaryItem}>
-							<strong>Skema Kerja:</strong> {formatEmployment(employmentType)} · {formatWorkplace(workplaceType)}
+							<strong>Employment & Workplace:</strong> {formatEmployment(employmentType)} · {formatWorkplace(workplaceType)}
 						</Text>
-						<Text style={summaryItemLabel}>Pesan / Gambaran Peran:</Text>
+						<Text style={summaryItemLabel}>Message / Role Overview:</Text>
 						<Text style={summaryMessage}>{message}</Text>
 					</Section>
 
@@ -127,7 +125,7 @@ export const ClientHireRequestAutoReplyEmail = ({
 
 					<Section style={footerSection}>
 						<Text style={footerText}>
-							Email ini dikirim secara otomatis sebagai tanda terima pesan penawaran kerja sama/rekrutmen.
+							This is an automated confirmation that your opportunity / hire request has been received.
 						</Text>
 						{refId && (
 							<Text style={refFooterText}>

--- a/src/components/emails/client-service-request-auto-reply.tsx
+++ b/src/components/emails/client-service-request-auto-reply.tsx
@@ -29,7 +29,7 @@ export const ClientServiceRequestAutoReplyEmail = ({
 	projectDetails,
 	refId,
 }: ClientServiceRequestAutoReplyProps) => {
-	const previewText = `Terima kasih atas permintaan proyek Anda, ${name}! - Wisman Nur`;
+	const previewText = `Thank you for your project request, ${name}! - Wisman Nur`;
 
 	return (
 		<Html>
@@ -39,39 +39,39 @@ export const ClientServiceRequestAutoReplyEmail = ({
 				<Container style={container}>
 					<Section style={headerSection}>
 						<Text style={brand}>Wisman Nur · Project Inquiry</Text>
-						<Heading style={headerTitle}>Permintaan Proyek Anda Diterima 🚀</Heading>
-						<Text style={headerSubtitle}>Terima kasih telah mempercayakan kebutuhan Anda.</Text>
+						<Heading style={headerTitle}>Project Request Received 🚀</Heading>
+						<Text style={headerSubtitle}>Thank you for reaching out.</Text>
 					</Section>
 
 					<Section style={bodySection}>
-						<Text style={greeting}>Halo {name},</Text>
+						<Text style={greeting}>Hi {name},</Text>
 						<Text style={paragraph}>
-							Terima kasih telah mengajukan permintaan kerja sama untuk layanan{" "}
-							<strong>{serviceType}</strong> melalui{" "}
+							Thank you for submitting a project request for{" "}
+							<strong>{serviceType}</strong> services via{" "}
 							<Link href="https://wismannur.pro/hire-me" style={linkStyle}>
 								wismannur.pro/hire-me
 							</Link>
 							.
 						</Text>
 						<Text style={paragraph}>
-							Saya akan meninjau detail proyek serta ketersediaan jadwal, dan akan segera membalas
-							dengan estimasi atau langkah selanjutnya maksimal dalam waktu{" "}
-							<strong>1x24 jam</strong> kerja.
+							I will review the project details and schedule availability, and will get back to you
+							with an estimate and next steps within{" "}
+							<strong>24 business hours</strong>.
 						</Text>
 					</Section>
 
 					<Section style={summaryCard}>
-						<Text style={summaryLabel}>Ringkasan Permintaan Proyek:</Text>
+						<Text style={summaryLabel}>Project Request Summary:</Text>
 						<Text style={summaryItem}>
-							<strong>Layanan:</strong> {serviceType}
+							<strong>Service:</strong> {serviceType}
 						</Text>
 						<Text style={summaryItem}>
-							<strong>Estimasi Budget:</strong> {budget}
+							<strong>Estimated Budget:</strong> {budget}
 						</Text>
 						<Text style={summaryItem}>
-							<strong>Target Waktu:</strong> {timeframe}
+							<strong>Target Timeframe:</strong> {timeframe}
 						</Text>
-						<Text style={summaryItemLabel}>Detail Kebutuhan:</Text>
+						<Text style={summaryItemLabel}>Project Details:</Text>
 						<Text style={summaryMessage}>{projectDetails}</Text>
 					</Section>
 
@@ -99,7 +99,7 @@ export const ClientServiceRequestAutoReplyEmail = ({
 
 					<Section style={footerSection}>
 						<Text style={footerText}>
-							Email ini dikirim secara otomatis sebagai tanda terima resmi permohonan layanan.
+							This is an automated confirmation that your project request has been received.
 						</Text>
 						{refId && (
 							<Text style={refFooterText}>

--- a/src/components/emails/job-outreach-email.tsx
+++ b/src/components/emails/job-outreach-email.tsx
@@ -43,13 +43,13 @@ export const JobOutreachEmail = ({
 			<Body style={main}>
 				<Container style={container}>
 					<Section style={bodySection}>
-						<Text style={greeting}>Halo {contactName || "Team"},</Text>
+						<Text style={greeting}>Hi {contactName || "Team"},</Text>
 						<Text style={messageContent}>{bodyMessage}</Text>
 					</Section>
 
 					{attachments.length > 0 && (
 						<Section style={attachmentSection}>
-							<Text style={attachmentHeading}>📎 Lampiran Dokumen:</Text>
+							<Text style={attachmentHeading}>📎 Attachments:</Text>
 							{attachments.map((att, idx) => (
 								<Text key={idx} style={attachmentItem}>
 									•{" "}

--- a/src/lib/email-cleaner.ts
+++ b/src/lib/email-cleaner.ts
@@ -1,0 +1,72 @@
+/**
+ * Cleans an email body by stripping out zero-width chars, previous email blockquotes,
+ * multiline quote headers (e.g. "On ... wrote:" / "Pada ... menulis:"), Outlook headers,
+ * and email thread footer artifacts.
+ */
+export function cleanReplyBody(text: string): string {
+	if (!text) return "";
+
+	// 1. Remove zero-width & invisible unicode whitespace (common in email preheaders/preview text)
+	let cleaned = text.replace(/[\u200B-\u200D\uFEFF\u200E\u200F\u061C\u00AD]/g, "");
+
+	// 2. Normalize CRLF to LF
+	cleaned = cleaned.replace(/\r\n/g, "\n");
+
+	// 3. Cut off at standard multi-line quote headers (Gmail, Apple Mail, Outlook, Thunderbird, Yahoo)
+	const quoteHeaderPatterns = [
+		// Gmail / Apple Mail / Thunderbird multiline "On ... wrote:" or "Pada ... menulis:"
+		/\n\s*(?:On|Pada|Le|El|Am|Op|Em)\s+[\s\S]+?(?:wrote|menulis|a écrit|escribió|schrieb|schreef|escreveu)\s*:\s*(?:\n|$)/i,
+		// Outlook standard divider header
+		/\n\s*-+\s*(?:Original Message|Pesan Asli|Forwarded [Mm]essage)\s*-+\s*(?:\n|$)/i,
+		// Outlook / Webmail header block (From: ... Sent: ... / Dari: ... Terkirim: ...)
+		/\n\s*(?:From|Dari):\s*.+?\n\s*(?:Sent|Terkirim|Date|Tanggal):\s*.+?(?:\n|$)/i,
+		// Underscore or dash dividers before quote
+		/\n\s*_{5,}\s*(?:\n|$)/,
+		/\n\s*-{5,}\s*(?:\n|$)/,
+	];
+
+	for (const pattern of quoteHeaderPatterns) {
+		const match = cleaned.match(pattern);
+		if (match && typeof match.index === "number") {
+			cleaned = cleaned.substring(0, match.index);
+		}
+	}
+
+	// 4. Line-by-line inspection for blockquotes (> ...) and trailing artifacts
+	const lines = cleaned.split("\n");
+	const resultLines: string[] = [];
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+		const trimmed = line.trim();
+
+		// Single-line quote headers
+		if (/^(?:On|Pada|Le|El|Am)\s.+?(?:wrote|menulis|a écrit|escribió|schrieb):$/i.test(trimmed)) {
+			break;
+		}
+
+		// Two-line quote headers where line 1 starts with "On / Pada" and line 2 is "wrote: / menulis:"
+		if (
+			/^(?:On|Pada|Le|El|Am)\s/i.test(trimmed) &&
+			i + 1 < lines.length &&
+			/^(?:wrote|menulis|a écrit|escribió|schrieb):$/i.test(lines[i + 1].trim())
+		) {
+			break;
+		}
+
+		// Blockquote lines
+		if (trimmed.startsWith(">") || trimmed.startsWith("&gt;")) {
+			break;
+		}
+
+		// Stop at isolated ref/signature artifacts
+		if (/^(?:Ref:\s*#?(?:contact|service|hire|outreach)|Sent from my|Kirim dari)/i.test(trimmed)) {
+			break;
+		}
+
+		resultLines.push(line);
+	}
+
+	const finalBody = resultLines.join("\n").trim();
+	return finalBody || text.trim();
+}

--- a/src/services/core/resend.ts
+++ b/src/services/core/resend.ts
@@ -191,7 +191,7 @@ export async function sendContactEmails(
 				from: SENDER_HI,
 				to: payload.email,
 				replyTo: dynamicReplyTo,
-				subject: "Pesan Anda telah diterima - Wisman Nur",
+				subject: "Message received - Wisman Nur",
 				headers: payload.id ? { "X-Entity-Ref-ID": payload.id } : undefined,
 				react: ClientContactAutoReplyEmail({
 					name: payload.name,
@@ -256,7 +256,7 @@ export async function sendServiceRequestEmails(
 				from: SENDER_HI,
 				to: payload.email,
 				replyTo: dynamicReplyTo,
-				subject: "Permintaan proyek diterima - Wisman Nur",
+				subject: "Project request received - Wisman Nur",
 				headers: payload.id ? { "X-Entity-Ref-ID": payload.id } : undefined,
 				react: ClientServiceRequestAutoReplyEmail({
 					name: payload.name,
@@ -325,7 +325,7 @@ export async function sendHireRequestEmails(
 				from: SENDER_HI,
 				to: payload.email,
 				replyTo: dynamicReplyTo,
-				subject: `Pesan penawaran posisi ${payload.roleTitle} diterima - Wisman Nur`,
+				subject: `Opportunity received: ${payload.roleTitle} - Wisman Nur`,
 				headers: payload.id ? { "X-Entity-Ref-ID": payload.id } : undefined,
 				react: ClientHireRequestAutoReplyEmail({
 					name: payload.name,
@@ -413,7 +413,7 @@ export async function sendInboundAlertToAdmin(payload: InboundAlertPayload): Pro
 	try {
 		const alertSubject = payload.isNewConversation
 			? `[New Direct Email] ${payload.clientName}: ${payload.subject}`
-			: `[Inbound Reply] ${payload.clientName} membalas: ${payload.subject}`;
+			: `[Inbound Reply] ${payload.clientName} replied: ${payload.subject}`;
 
 		const alertReact = payload.isNewConversation
 			? AdminDirectEmailAlertEmail({

--- a/src/services/inquiry-messages/actions.ts
+++ b/src/services/inquiry-messages/actions.ts
@@ -61,29 +61,33 @@ export async function sendAdminReply(data: SendAdminReplyInput): Promise<Inquiry
 		.orderBy(asc(inquiryMessages.createdAt));
 
 	const referencesIds: string[] = [];
+	let initialEntityMessage: string | undefined = undefined;
 
-	// Check initial messageId from parent table
+	// Check initial messageId and message content from parent table
 	if (clean.inquiryType === "contact") {
 		const [parent] = await db
-			.select({ messageId: contacts.messageId })
+			.select({ messageId: contacts.messageId, message: contacts.message })
 			.from(contacts)
 			.where(eq(contacts.id, clean.inquiryId))
 			.limit(1);
 		if (parent?.messageId) referencesIds.push(parent.messageId);
+		if (parent?.message) initialEntityMessage = parent.message;
 	} else if (clean.inquiryType === "service_request") {
 		const [parent] = await db
-			.select({ messageId: serviceRequests.messageId })
+			.select({ messageId: serviceRequests.messageId, projectDetails: serviceRequests.projectDetails })
 			.from(serviceRequests)
 			.where(eq(serviceRequests.id, clean.inquiryId))
 			.limit(1);
 		if (parent?.messageId) referencesIds.push(parent.messageId);
+		if (parent?.projectDetails) initialEntityMessage = parent.projectDetails;
 	} else if (clean.inquiryType === "hire_request") {
 		const [parent] = await db
-			.select({ messageId: hireRequests.messageId })
+			.select({ messageId: hireRequests.messageId, message: hireRequests.message })
 			.from(hireRequests)
 			.where(eq(hireRequests.id, clean.inquiryId))
 			.limit(1);
 		if (parent?.messageId) referencesIds.push(parent.messageId);
+		if (parent?.message) initialEntityMessage = parent.message;
 	}
 
 	for (const msg of previousMessages) {
@@ -95,6 +99,17 @@ export async function sendAdminReply(data: SendAdminReplyInput): Promise<Inquiry
 	const inReplyToId =
 		referencesIds.length > 0 ? referencesIds[referencesIds.length - 1] : null;
 
+	// Find the most recent message from the client to quote dynamically in the email
+	const latestClientMessage = [...previousMessages]
+		.reverse()
+		.find((msg) => msg.senderType === "client");
+
+	const originalSnippetToQuote =
+		latestClientMessage?.message ||
+		clean.originalMessageSnippet ||
+		initialEntityMessage ||
+		undefined;
+
 	// 2. Send email to client via Resend with RFC 5322 In-Reply-To and References
 	const sendRes = await sendAdminReplyToClient({
 		inquiryId: clean.inquiryId,
@@ -102,7 +117,7 @@ export async function sendAdminReply(data: SendAdminReplyInput): Promise<Inquiry
 		toName: clean.toName,
 		subject: clean.subject,
 		message: clean.message,
-		originalMessageSnippet: clean.originalMessageSnippet,
+		originalMessageSnippet: originalSnippetToQuote,
 		inReplyToId,
 		referencesIds,
 	});


### PR DESCRIPTION
## Summary
- Introduces robust email body cleaning utility to remove multiline reply headers (Gmail, Outlook, Yahoo) and zero-width unicode artifacts from inbound emails.
- Updates admin reply workflow to dynamically quote the latest client message snippet instead of always quoting the initial inquiry.
- Translates all Indonesian UI strings, toast notifications, confirmation dialogs, and email templates across CMS and core transactional email services to English.

## Changes
- `feat(inbound): clean multiline quote headers and unicode artifacts from email bodies`
- `feat(inquiry-messages): quote latest client message dynamically in admin replies`
- `refactor(emails): translate email templates and subject lines to english`
- `refactor(cms): translate inquiry and job outreach interfaces to english`

## Test plan
- [x] Run `pnpm typecheck` (`tsc --noEmit`) — Exit code 0.
- [x] Tested email cleaner against multiline quotes and zero-width spaces.
- [x] Verified CMS inquiry detail pages and email templates.